### PR TITLE
Removed old GitHub templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,3 +1,0 @@
-Please do NOT create new issues here! Instead, use the new Eclipse Krazo issue tracker:
-
-https://github.com/eclipse-ee4j/krazo/issues

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-Please don't create new pull requests. We are currently migrating the source code to the Eclipse Krazo project. Please watch the mailing list about the current status.


### PR DESCRIPTION
There are still issue / pull request templates which tell people to NOT use the repository. I forgot to exclude them from the initial contribution.

Let's see if the Travis integration works....