### PR TITLE
Some pom.xml improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,37 @@
             </build>
         </profile>
 
+        <!-- Profile to enable ossrh snapshots -->
+        <profile>
+            <id>snapshots</id>
+            <repositories>
+                <repository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
I'm currently working on getting the Krazo snapshots to the OSSRH repository. The PR contains two important fixes for our pom.

- Currently Krazo doesn't build correctly on our [Jenkins instance](https://jenkins.eclipse.org/krazo/), because it depends on a snapshot version of the TCK. On Travis the OSSRH snapshot repository is enabled automatically, but this is not the case on Jenkins. Therefore, I added a special profile which can be used to enable the snapshot repository for the pom.
- The other commit tweaks the GPG arguments used when signing the artifacts. Newer versions of GPG require this option to be set, so we can sign the artifacts when running snapshot deployments and/or releases from Jenkins. This is also documented in the [EE4J wiki](https://wiki.eclipse.org/EE4J_Build#Required_steps_for_a_freestyle_build_job).



