### PR TITLE
Fixed broken trace log message

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptor.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptor.java
@@ -111,7 +111,7 @@ public class ValidationInterceptor implements Serializable {
             return;
         }
 
-        log.log(Level.FINE, "Validation found {} constraint violations...", violations.size());
+        log.log(Level.FINE, "Validation found {0} constraint violations...", violations.size());
 
         Set<ValidationError> validationErrors = new LinkedHashSet<>();
 


### PR DESCRIPTION
The log message here is incorrect and is causing an exception if the log level is enabled.