### PR TITLE
Updated all integration test containers to latest version

### DIFF
--- a/.travis/docker-wildfly.sh
+++ b/.travis/docker-wildfly.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-docker pull jboss/wildfly:14.0.1.Final
-docker run --name=wildfly -d -p 8080:8080 -p 9990:9990 -it jboss/wildfly:14.0.1.Final /opt/jboss/wildfly/bin/standalone.sh -bmanagement 0.0.0.0 -b 0.0.0.0
+docker pull jboss/wildfly:15.0.1.Final
+docker run --name=wildfly -d -p 8080:8080 -p 9990:9990 -it jboss/wildfly:15.0.1.Final /opt/jboss/wildfly/bin/standalone.sh -bmanagement 0.0.0.0 -b 0.0.0.0
 docker exec wildfly /opt/jboss/wildfly/bin/add-user.sh admin wildfly

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-GLASSFISH_URL="https://repo1.maven.org/maven2/org/glassfish/main/distributions/web/5.1.0-RC1/web-5.1.0-RC1.zip"
-WILDFLY_URL="http://download.jboss.org/wildfly/14.0.1.Final/wildfly-14.0.1.Final.tar.gz"
-LIBERTY_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/18.0.0.3/wlp-webProfile7-18.0.0.3.zip"
+GLASSFISH_URL="http://download.eclipse.org/glassfish/web-5.1.0.zip"
+WILDFLY_URL="https://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz"
+LIBERTY_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/19.0.0.1/wlp-webProfile8-19.0.0.1.zip"
 
 if [ "${1}" == "glassfish-bundled" ]; then
 
@@ -48,7 +48,7 @@ elif [ "${1}" == "tck-wildfly" ]; then
   curl -L -s -o wildfly.tgz "${WILDFLY_URL}"
   tar -xzf wildfly.tgz
   mvn -B -V -DskipTests clean install
-  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-14.0.1.Final/bin/standalone.sh > wildfly.log 2>&1 &
+  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-15.0.1.Final/bin/standalone.sh > wildfly.log 2>&1 &
   sleep 30
   pushd tck
   mvn -B -V -Dtck-env=wildfly verify

--- a/.travis/wlp-server-template.xml
+++ b/.travis/wlp-server-template.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>webProfile-7.0</feature>
+        <feature>webProfile-8.0</feature>
 
         <!-- For Arquillian -->
         <feature>jsp-2.2</feature>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -194,7 +194,7 @@
                 </property>
             </activation>
             <properties>
-                <tomee.version>7.1.0</tomee.version>
+                <tomee.version>8.0.0-M2</tomee.version>
                 <tomee.classifier>webprofile</tomee.classifier>
             </properties>
             <build>
@@ -259,7 +259,7 @@
                 <dependency>
                     <groupId>io.openliberty.arquillian</groupId>
                     <artifactId>arquillian-liberty-managed</artifactId>
-                    <version>1.0.0</version>
+                    <version>1.0.3</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
This PR updates the container versions we run the TCK tests against:

  * Glassfish 5.1.0-RC1 to Eclipse Glassfish 5.1.0.Final
  * Wildfly 14.0.1.Final to 15.0.1.Final
  * TomEE 7.1.0 to 8.0.0-M2
  * Liberty 18.0.0.3 to 19.0.0.1

I checked the build results and everything looks fine (which means that the builds are still failing due to the compatibility issues we already know about).