### PR TITLE
Set more provider priorities for correct ordering

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverterProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.eclipse.krazo.binding.convert;
 import org.eclipse.krazo.binding.BindingErrorImpl;
 import org.eclipse.krazo.binding.BindingResultImpl;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.mvc.MvcContext;
 import javax.mvc.binding.MvcBinding;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
  *
  * @author Christian Kaltepoth
  */
+@Priority(0)  // should be preferred over builtin providers
 public class MvcConverterProvider implements ParamConverterProvider {
 
     @Inject

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfExceptionMapper.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
  */
 package org.eclipse.krazo.security;
 
+import javax.annotation.Priority;
 import javax.mvc.security.CsrfValidationException;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -26,6 +28,7 @@ import javax.ws.rs.ext.ExceptionMapper;
  *
  * @author Christian Kaltepoth
  */
+@Priority(Priorities.USER + 5000)    // User provided mappers must be preferred
 public class CsrfExceptionMapper implements ExceptionMapper<CsrfValidationException> {
 
     @Override


### PR DESCRIPTION
Some of our JAX-RS providers were missing `@Priority` annotations to enforce a specific ordering. I think that I omitted them back then because I wasn't seeing consistent behavior with Jersey 2.26 anyway. But as we are not targeting more servers, we should specify them correctly. Maybe this will work with Jersey 2.28 now.