### PR TITLE
Allow to change name of CSRF HTTP header

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
+++ b/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
@@ -59,7 +59,9 @@ public class KrazoConfig {
         }
 
         // default
-        return new SessionCsrfTokenStrategy.Builder().build();
+        return new SessionCsrfTokenStrategy.Builder()
+                .headerName(getCsrfHeaderName())
+                .build();
 
     }
 
@@ -69,6 +71,19 @@ public class KrazoConfig {
             return (String) value;
         }
         return null;
+    }
+
+    public String getCsrfHeaderName() {
+
+        // TODO: Replace with constant from Csrf class after updating spec dependency
+        Object value = config.getProperty("javax.mvc.security.CsrfHeaderName");
+        if (value != null) {
+            return value.toString();
+        }
+
+        // TODO: Replace with constant from Csrf class after updating spec dependency
+        return "X-CSRF-TOKEN";
+
     }
 
 }


### PR DESCRIPTION
This PR contains the required changes to support customizable CSRF HTTP header names as introduced in the spec via mvc-spec/mvc-spec#209. 

Krazo currently still depends on the `1.0-pfd` release of the spec and I would like to keep this, so we can release as soon as possible without also having to release the spec. Therefore, I hardcoded the constants which were introduced in the spec.