### PR TITLE
Fixed NPE when binding empty strings to numeric types

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/DoubleConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/DoubleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ public class DoubleConverter extends NumberConverter<Double> {
     @Override
     public ConverterResult<Double> convert(String value, Class<Double> rawType, Locale locale) {
 
+        Double defaultValue = Double.TYPE.equals(rawType) ? 0.0 : null;
         try {
 
-            return ConverterResult.success(parseNumber(value, locale).doubleValue());
+            return ConverterResult.success(parseNumber(value, locale).map(Number::doubleValue).orElse(defaultValue));
 
         } catch (ParseException e) {
-            Double defaultValue = Double.TYPE.equals(rawType) ? 0.0 : null;
             return ConverterResult.failed(defaultValue, e.getMessage());
         }
 

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/FloatConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/FloatConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ public class FloatConverter extends NumberConverter<Float> {
     @Override
     public ConverterResult<Float> convert(String value, Class<Float> rawType, Locale locale) {
 
+        Float defaultValue = Float.TYPE.equals(rawType) ? 0.0f : null;
         try {
 
-            return ConverterResult.success(parseNumber(value, locale).floatValue());
+            return ConverterResult.success(parseNumber(value, locale).map(Number::floatValue).orElse(defaultValue));
 
         } catch (ParseException e) {
-            Float defaultValue = Float.TYPE.equals(rawType) ? 0.0f : null;
             return ConverterResult.failed(defaultValue, e.getMessage());
         }
 

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/IntegerConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/IntegerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ public class IntegerConverter extends NumberConverter<Integer> {
     @Override
     public ConverterResult<Integer> convert(String value, Class<Integer> rawType, Locale locale) {
 
+        Integer defaultValue = Integer.TYPE.equals(rawType) ? 0 : null;
         try {
 
-            return ConverterResult.success(parseNumber(value, locale).intValue());
+            return ConverterResult.success(parseNumber(value, locale).map(Number::intValue).orElse(defaultValue));
 
         } catch (ParseException e) {
-            Integer defaultValue = Integer.TYPE.equals(rawType) ? 0 : null;
             return ConverterResult.failed(defaultValue, e.getMessage());
         }
 

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/LongConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ public class LongConverter extends NumberConverter<Long> {
     @Override
     public ConverterResult<Long> convert(String value, Class<Long> rawType, Locale locale) {
 
+        Long defaultValue = Long.TYPE.equals(rawType) ? 0L : null;
         try {
 
-            return ConverterResult.success(parseNumber(value, locale).longValue());
+            return ConverterResult.success(parseNumber(value, locale).map(Number::longValue).orElse(defaultValue));
 
         } catch (ParseException e) {
-            Long defaultValue = Long.TYPE.equals(rawType) ? 0L : null;
             return ConverterResult.failed(defaultValue, e.getMessage());
         }
 

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/NumberConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/NumberConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,11 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Locale;
+import java.util.Optional;
 
 abstract class NumberConverter<T extends Number> implements MvcConverter<T> {
 
-    Number parseNumber(String value, Locale locale) throws ParseException {
+    Optional<Number> parseNumber(String value, Locale locale) throws ParseException {
 
         if (value != null && !value.trim().isEmpty()) {
 
@@ -39,10 +40,10 @@ abstract class NumberConverter<T extends Number> implements MvcConverter<T> {
                 throw new ParseException("Not a valid number: " + value.trim(), parsePosition.getIndex());
             }
 
-            return result;
+            return Optional.ofNullable(result);
 
         }
-        return null;
+        return Optional.empty();
 
     }
 }


### PR DESCRIPTION
I'm currently working on the TCK tests for the data binding chapter and ran into an NPE that is caused by a bug in Krazo. Basically the code wasn't handling empty strings correctly if they were bound to numeric types. For empty strings the correctly result should be either `null` (for wrapper types) or `0` for primitive types.

I think the diff is self-explanatory. `parseNumber` returned `null` for empty strings, but the calling code was just calling `.doubleValue()` (and other type dependent methods) on it without checking for `null`. With this fix applied I'm getting more green TCK tests! :+1: 