### PR TITLE
Added binding support for BigDecimal/BigInteger

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
@@ -17,6 +17,8 @@
  */
 package org.eclipse.krazo.binding.convert;
 
+import org.eclipse.krazo.binding.convert.impl.BigDecimalConverter;
+import org.eclipse.krazo.binding.convert.impl.BigIntegerConverter;
 import org.eclipse.krazo.binding.convert.impl.BooleanConverter;
 import org.eclipse.krazo.binding.convert.impl.DoubleConverter;
 import org.eclipse.krazo.binding.convert.impl.FloatConverter;
@@ -45,6 +47,8 @@ public class ConverterRegistry {
         register(new LongConverter());
         register(new DoubleConverter());
         register(new FloatConverter());
+        register(new BigDecimalConverter());
+        register(new BigIntegerConverter());
         register(new BooleanConverter());
     }
 

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.eclipse.krazo.binding.convert.ConverterResult;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Converter for double primitive or wrapper types.
+ *
+ * @author Christian Kaltepoth
+ */
+public class BigDecimalConverter extends NumberConverter<BigDecimal> {
+
+    @Override
+    public boolean supports(Class<BigDecimal> rawType) {
+        return BigDecimal.class.equals(rawType);
+    }
+
+    @Override
+    public ConverterResult<BigDecimal> convert(String value, Class<BigDecimal> rawType, Locale locale) {
+
+        try {
+
+            return ConverterResult.success(
+                    parseNumber(value, locale)
+                            .map(val -> new BigDecimal(val.toString()))
+                            .orElse(null)
+            );
+
+        } catch (ParseException e) {
+            return ConverterResult.failed(null, e.getMessage());
+        }
+
+    }
+}

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.eclipse.krazo.binding.convert.ConverterResult;
+
+import java.math.BigInteger;
+import java.text.ParseException;
+import java.util.Locale;
+
+/**
+ * Converter for double primitive or wrapper types.
+ *
+ * @author Christian Kaltepoth
+ */
+public class BigIntegerConverter extends NumberConverter<BigInteger> {
+
+    @Override
+    public boolean supports(Class<BigInteger> rawType) {
+        return BigInteger.class.equals(rawType);
+    }
+
+    @Override
+    public ConverterResult<BigInteger> convert(String value, Class<BigInteger> rawType, Locale locale) {
+
+        try {
+
+            return ConverterResult.success(
+                    parseNumber(value, locale)
+                            .map(val -> new BigInteger(val.toString()))
+                            .orElse(null)
+            );
+
+        } catch (ParseException e) {
+            return ConverterResult.failed(null, e.getMessage());
+        }
+
+    }
+}


### PR DESCRIPTION
I just noticed that we forgot to add MVC binding support for the data types `BigDecimal` and `BigInteger` as required by the spec. 