### PR TITLE
Test the binding package and fixed some minor issues

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,7 @@
  */
 package org.eclipse.krazo.binding.convert;
 
-import org.eclipse.krazo.binding.convert.impl.BigDecimalConverter;
-import org.eclipse.krazo.binding.convert.impl.BigIntegerConverter;
-import org.eclipse.krazo.binding.convert.impl.BooleanConverter;
-import org.eclipse.krazo.binding.convert.impl.DoubleConverter;
-import org.eclipse.krazo.binding.convert.impl.FloatConverter;
-import org.eclipse.krazo.binding.convert.impl.IntegerConverter;
-import org.eclipse.krazo.binding.convert.impl.LongConverter;
+import org.eclipse.krazo.binding.convert.impl.*;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -43,6 +37,7 @@ public class ConverterRegistry {
 
     @PostConstruct
     public void init() {
+        register(new ShortConverter());
         register(new IntegerConverter());
         register(new LongConverter());
         register(new DoubleConverter());

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/ShortConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/ShortConverter.java
@@ -19,35 +19,31 @@ package org.eclipse.krazo.binding.convert.impl;
 
 import org.eclipse.krazo.binding.convert.ConverterResult;
 
-import java.math.BigInteger;
 import java.text.ParseException;
 import java.util.Locale;
 
 /**
- * Converter for double primitive or wrapper types.
+ * Converter for integer primitive or wrapper types.
  *
  * @author Christian Kaltepoth
  */
-public class BigIntegerConverter extends NumberConverter<BigInteger> {
+public class ShortConverter extends NumberConverter<Short> {
 
     @Override
-    public boolean supports(Class<BigInteger> rawType) {
-        return BigInteger.class.equals(rawType);
+    public boolean supports(Class<Short> rawType) {
+        return Short.class.equals(rawType) || Short.TYPE.equals(rawType);
     }
 
     @Override
-    public ConverterResult<BigInteger> convert(String value, Class<BigInteger> rawType, Locale locale) {
+    public ConverterResult<Short> convert(String value, Class<Short> rawType, Locale locale) {
 
+        Short defaultValue = Short.TYPE.equals(rawType) ? (short) 0 : null;
         try {
 
-            return ConverterResult.success(
-                    parseNumber(value, locale)
-                            .map(val -> new BigInteger(val.toString()))
-                            .orElse(null)
-            );
+            return ConverterResult.success(parseNumber(value, locale).map(Number::shortValue).orElse(defaultValue));
 
-        } catch (ParseException | NumberFormatException e) {
-            return ConverterResult.failed(null, e.getMessage());
+        } catch (ParseException e) {
+            return ConverterResult.failed(defaultValue, e.getMessage());
         }
 
     }

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/ConverterRegistryTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/ConverterRegistryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import java.lang.annotation.Annotation;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+/**
+ * Asserts that converters for all supported types have been registered
+ * @author Gregor Tudan
+ */
+@RunWith(Parameterized.class)
+public class ConverterRegistryTest {
+
+    @Parameter
+    public Class<Object> type;
+
+    private ConverterRegistry registry;
+
+    @Before
+    public void setup() {
+        registry = new ConverterRegistry();
+        registry.init();
+    }
+
+    @Parameterized.Parameters(name = "test that {0} has a converter")
+    public static Collection<Object> parameters() {
+        return Arrays.asList(
+            Short.class,
+            Long.class,
+            Integer.class,
+            Long.class,
+            Float.class,
+            Double.class,
+            BigInteger.class,
+            BigDecimal.class
+        );
+    }
+
+    @Test
+    public void testConverterRegistered() {
+        MvcConverter converter = registry.lookup(type, new Annotation[]{});
+        assertNotNull(converter);
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class BigDecimalConverterTest {
+
+    public static class ConversionTests extends ConversionTest<BigDecimal> {
+
+        public ConversionTests() {
+            super(new BigDecimalConverter(), BigDecimal.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", BigDecimal.valueOf(12), false},
+                new Object[]{"12.2", BigDecimal.valueOf(12.2), false},
+                new Object[]{"0", BigDecimal.ZERO, false},
+                new Object[]{"-2", BigDecimal.valueOf(-2), false},
+                new Object[]{"3E2", new BigDecimal("300"), false},
+                new Object[]{"", null, false},
+                new Object[]{"NaN", null, true},
+                new Object[]{"asd", null, true},
+                new Object[]{null, null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<BigDecimal> {
+
+        public Supports() {
+            super(new BigDecimalConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{BigDecimal.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Float.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class BigIntegerConverterTest {
+
+    public static class ConversionTests extends ConversionTest<BigInteger> {
+
+        public ConversionTests() {
+            super(new BigIntegerConverter(), BigInteger.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", BigInteger.valueOf(12), false},
+                new Object[]{"0", BigInteger.ZERO, false},
+                new Object[]{"-2", BigInteger.valueOf(-2), false},
+                new Object[]{"3E2", new BigInteger("300"), false},
+                new Object[]{"", null, false},
+                new Object[]{"asd", null, true},
+                new Object[]{null, null, false},
+                new Object[]{"NaN", null, true},
+                new Object[]{"12.2", null, true}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<BigInteger> {
+
+        public Supports() {
+            super(new BigIntegerConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{BigInteger.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Float.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class BooleanConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Boolean> {
+
+        public ConversionTests() {
+            super(new BooleanConverter(), Boolean.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"true", true, false},
+                new Object[]{"TRUE", true, false},
+                new Object[]{"on", true, false},
+                new Object[]{"false", false, false},
+                new Object[]{"off", false, false},
+                new Object[]{"null", false, false},
+                new Object[]{"baz", false, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Boolean> {
+
+        public Supports() {
+            super(new BooleanConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Boolean.class, true},
+                new Object[]{Integer.class, false},
+                new Object[]{null, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ConversionTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ConversionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.eclipse.krazo.binding.convert.ConverterResult;
+import org.eclipse.krazo.binding.convert.MvcConverter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Parameterized.class)
+public abstract class ConversionTest<T> {
+    private final MvcConverter<T> converter;
+    private Class<T> clazz;
+
+    @Parameterized.Parameter(0)
+    public String value;
+    @Parameterized.Parameter(1)
+    public T convertedValue;
+    @Parameterized.Parameter(2)
+    public boolean isError;
+
+    ConversionTest(MvcConverter<T> converter, Class<T> clazz) {
+        this.converter = converter;
+        this.clazz = clazz;
+    }
+
+    @Test
+    public void testConversionErrors() {
+        ConverterResult<T> converterResult = converter.convert(value, clazz, Locale.ENGLISH);
+
+        assertEquals(convertedValue, converterResult.getValue());
+        if (isError) {
+            assertTrue(converterResult.getError().isPresent());
+            assertFalse(converterResult.getError().get().isEmpty());
+        } else {
+            assertFalse(converterResult.getError().isPresent());
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/DoubleConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/DoubleConverterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class DoubleConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Double> {
+
+        public ConversionTests() {
+            super(new DoubleConverter(), Double.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", 12d, false},
+                new Object[]{"12.2", 12.2d, false},
+                new Object[]{"0", 0d, false},
+                new Object[]{"-2", -2d, false},
+                new Object[]{"", null, false},
+                new Object[]{"asd", null, true},
+                new Object[]{null, null, false},
+                new Object[]{"3E2", 300d, false}
+                // Flaky test: NaN resolves to 0 (java 11) or null (java 8) in the long-converter.
+                // It triggers a binding error in java 8, but not in java 11
+                //new Object[]{"NaN", null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Double> {
+
+        public Supports() {
+            super(new DoubleConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Double.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Float.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/FloatConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/FloatConverterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class FloatConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Float> {
+
+        public ConversionTests() {
+            super(new FloatConverter(), Float.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", 12f, false},
+                new Object[]{"12.2", 12.2f, false},
+                new Object[]{"0", 0f, false},
+                new Object[]{"-2", -2f, false},
+                new Object[]{"3E2", 300f, false},
+                new Object[]{"", null, false},
+                new Object[]{"asd", null, true},
+                new Object[]{null, null, false}
+                // Flaky test: NaN resolves to 0 (java 11) or null (java 8)
+                // It triggers a binding error in java 8, but not in java 11
+                // new Object[]{"NaN", null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Float> {
+
+        public Supports() {
+            super(new FloatConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Float.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Double.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/IntegerConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/IntegerConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class IntegerConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Integer> {
+
+        public ConversionTests() {
+            super(new IntegerConverter(), Integer.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", 12, false},
+                new Object[]{"0", 0, false},
+                new Object[]{"-2", -2, false},
+                new Object[]{"3E2", 300, false},
+                new Object[]{"", null, false},
+                new Object[]{null, null, false},
+                new Object[]{"asd", null, true}
+                // Flaky test: NaN resolves to 0 (java 11) or null (java 8) in the long-converter.
+                // It triggers a binding error in java 8, but not in java 11
+                //new Object[]{"NaN", null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Integer> {
+
+        public Supports() {
+            super(new IntegerConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Integer.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Double.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/LongConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/LongConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class LongConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Long> {
+
+        public ConversionTests() {
+            super(new LongConverter(), Long.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", 12L, false},
+                new Object[]{"0", 0L, false},
+                new Object[]{"-2", -2L, false},
+                new Object[]{"3E2", 300L, false},
+                new Object[]{"asd", null, true},
+                new Object[]{"", null, false},
+                new Object[]{null, null, false}
+                // Flaky test: NaN resolves to 0 (java 11) or null (java 8) in the long-converter.
+                // It triggers a binding error in java 8, but not in java 11
+                //new Object[]{"NaN", null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Long> {
+
+        public Supports() {
+            super(new LongConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Long.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Integer.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ShortConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ShortConverterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Enclosed.class)
+public class ShortConverterTest {
+
+    public static class ConversionTests extends ConversionTest<Short> {
+
+        public ConversionTests() {
+            super(new ShortConverter(), Short.class);
+        }
+
+        @Parameters(name = "{0} converts to {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{"12", (short) 12, false},
+                new Object[]{"0", (short) 0, false},
+                new Object[]{"-2", (short) -2, false},
+                new Object[]{"3E2", (short) 300, false},
+                new Object[]{"", null, false},
+                new Object[]{null, null, false},
+                new Object[]{"asd", null, true}
+                // Flaky test: NaN resolves to 0 (java 11) or null (java 8) in the long-converter.
+                // It triggers a binding error in java 8, but not in java 11
+                //new Object[]{"NaN", null, false}
+            );
+        }
+    }
+
+    public static class Supports extends SupportsTest<Short> {
+
+        public Supports() {
+            super(new ShortConverter());
+        }
+
+        @Parameters(name = "supports {0} = {1}")
+        public static List<Object[]> getParameters() {
+            return Arrays.asList(
+                new Object[]{Short.class, true},
+                new Object[]{Number.class, false},
+                new Object[]{Object.class, false},
+                new Object[]{Double.class, false},
+                new Object[]{List.class, false}
+            );
+        }
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.binding.convert.impl;
+
+import org.eclipse.krazo.binding.convert.MvcConverter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Gregor Tudan
+ */
+@RunWith(Parameterized.class)
+public abstract class SupportsTest<T> {
+
+    private MvcConverter<T> mvcConverter;
+
+    SupportsTest(MvcConverter<T> mvcConverter) {
+        this.mvcConverter = mvcConverter;
+    }
+
+    @Parameter(0)
+    public Class clazz;
+    @Parameter(1)
+    public boolean isSupported;
+
+    @Test
+    public void testSupports() {
+       if (isSupported) {
+           assertTrue(mvcConverter.supports(clazz));
+       } else {
+           assertFalse(mvcConverter.supports(clazz));
+       }
+    }
+
+}


### PR DESCRIPTION
I was doing some low-energy work and started testing the converter package. There are some edge-cases that we don't handle correctly:

* Float and Double usually return NaN - but not always
* There were uncaugt NumberFormatExceptions with BigDecimal and BigInteger

There are still some flaky tests, which I left commented out - the parse behavior slightly changed from Java 8 to 11. It's not that bad, but a little supprising ("NaN" is a valid Number and won't trigger binding errors).

It's a little strange that nearly all converters handle numbers, but we don't have a converter that supports the abstract `Number`-Type as a result. Should we pick one that handles this (Double?)

We also forgot about `Short` should we add a converter for it?