### PR TITLE
Print view in Viewable toString for easier debugging

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
@@ -136,4 +136,9 @@ public class Viewable {
     public void setViewEngine(Class<? extends ViewEngine> viewEngine) {
         this.viewEngine = viewEngine;
     }
+
+    @Override
+    public String toString() {
+        return view;
+    }
 }

--- a/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017-2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When a ViewEngine is not found for a view, the Viewable's Object#toString is called and the message in the stacktrace is not really helpful. This way it should simply print the Viewable#view to identify what causes the exception.

Signed-off-by: Erdle, Tobias <tobias.erdle@innoq.com>