### PR TITLE
Patch Jersey version in Glassfish 5.1.0 for TCK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ jobs:
       before_script: .travis/docker-payara.sh
       script: mvn -P${TYPE} --projects testsuite clean verify
     - stage: test
-      env: TYPE=tck-glassfish
+      env: TYPE=tck-glassfish-vanilla
+      script: .travis/tests.sh ${TYPE}
+    - stage: test
+      env: TYPE=tck-glassfish-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
       env: TYPE=tck-wildfly
@@ -36,7 +39,8 @@ jobs:
       env: TYPE=tck-liberty
       script: .travis/tests.sh ${TYPE}
   allow_failures:
-    - env: TYPE=tck-glassfish
+    - env: TYPE=tck-glassfish-vanilla
+    - env: TYPE=tck-glassfish-patched
     - env: TYPE=tck-wildfly
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -31,10 +31,23 @@ elif [ "${1}" == "glassfish-module" ]; then
   mvn -Pintegration -Dintegration.serverPort=8080 verify
   glassfish5/bin/asadmin stop-domain
 
-elif [ "${1}" == "tck-glassfish" ]; then
+elif [ "${1}" == "tck-glassfish-vanilla" ]; then
 
   curl -L -s -o glassfish5.zip "${GLASSFISH_URL}"
   unzip -q glassfish5.zip
+  mvn -B -V -DskipTests clean install
+  glassfish5/bin/asadmin start-domain
+  sleep 30
+  pushd tck
+  mvn -B -V -Dtck-env=glassfish verify
+  popd
+  glassfish5/bin/asadmin stop-domain
+
+elif [ "${1}" == "tck-glassfish-patched" ]; then
+
+  curl -L -s -o glassfish5.zip "${GLASSFISH_URL}"
+  unzip -q glassfish5.zip
+  curl -L -s -o glassfish5/glassfish/modules/jersey-cdi1x.jar "https://www.dropbox.com/s/wc2ukjns388lwir/jersey-cdi1x-2.28-fix1.jar"
   mvn -B -V -DskipTests clean install
   glassfish5/bin/asadmin start-domain
   sleep 30


### PR DESCRIPTION
I adjusted our test script to replace one of the Jersey modules shipping with Eclipse Glassfish 5.1.0 with a patched version. Let see if this fixes some of the errors we get when running the TCK against Eclipse Glassfish 5.1.0.

Travis, please test! :-)