### PR TITLE
Fixed BooleanConverter to handle empty strings correctly

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BooleanConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BooleanConverter.java
@@ -37,8 +37,13 @@ public class BooleanConverter implements MvcConverter<Boolean> {
     @Override
     public ConverterResult<Boolean> convert(String value, Class<Boolean> rawType, Locale locale) {
 
+        Boolean defaultValue = Boolean.TYPE.equals(rawType) ? false : null;
+
         String normalized = value != null ? value.trim().toLowerCase() : "";
-        return ConverterResult.success("on".equals(normalized) || "true".equals(normalized));
+
+        return "".equals(normalized)
+                ? ConverterResult.success(defaultValue)
+                : ConverterResult.success("on".equals(normalized) || "true".equals(normalized));
 
     }
 }

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
@@ -45,7 +45,9 @@ public class BooleanConverterTest {
                 new Object[]{"false", false, false},
                 new Object[]{"off", false, false},
                 new Object[]{"null", false, false},
-                new Object[]{"baz", false, false}
+                new Object[]{"baz", false, false},
+                new Object[]{"", null, false},
+                new Object[]{null, null, false}
             );
         }
     }


### PR DESCRIPTION
The spec states:

> Empty strings are converted to `false` in case of the primitive boolean type and to `null` for the wrapper type.

Krazo doesn't handle this case correctly which causes a broken TCK test.