### PR TITLE
Added new TCK profile for patched Wildfly 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ jobs:
       env: TYPE=tck-glassfish-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
-      env: TYPE=tck-wildfly
+      env: TYPE=tck-wildfly16-vanilla
+      script: .travis/tests.sh ${TYPE}
+    - stage: test
+      env: TYPE=tck-wildfly16-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
       env: TYPE=tck-tomee
@@ -41,7 +44,8 @@ jobs:
   allow_failures:
     - env: TYPE=tck-glassfish-vanilla
     - env: TYPE=tck-glassfish-patched
-    - env: TYPE=tck-wildfly
+    - env: TYPE=tck-wildfly16-vanilla
+    - env: TYPE=tck-wildfly16-patched
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty
     - env: TYPE=glassfish-module


### PR DESCRIPTION
This PR creates a new TCK profile for running against a patched version of Wildfly 16. Unfortunately the handling of validation errors is currently broken in Wildfly 16 because of [WELD-2568](https://issues.jboss.org/browse/WELD-2568). This issue has been fixed for the current Weld snapshots (see weld/core#1907). I backported the fix and the new profile basically just replaces the corresponding Weld JAR file.

I hope that the `*-patched` profiles allow us to verify that Krazo works flawless on the upcoming Wildfly release. :-)