### PR TITLE
Apply another Jersey fix in the (patched) Glassfish TCK profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
       script: .travis/tests.sh ${TYPE}
   allow_failures:
     - env: TYPE=tck-glassfish51-vanilla
-    - env: TYPE=tck-glassfish51-patched
     - env: TYPE=tck-wildfly16-vanilla
     - env: TYPE=tck-wildfly16-patched
     - env: TYPE=tck-tomee

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ jobs:
       before_script: .travis/docker-payara.sh
       script: mvn -P${TYPE} --projects testsuite clean verify
     - stage: test
-      env: TYPE=tck-glassfish-vanilla
+      env: TYPE=tck-glassfish51-vanilla
       script: .travis/tests.sh ${TYPE}
     - stage: test
-      env: TYPE=tck-glassfish-patched
+      env: TYPE=tck-glassfish51-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
       env: TYPE=tck-wildfly16-vanilla
@@ -42,8 +42,8 @@ jobs:
       env: TYPE=tck-liberty
       script: .travis/tests.sh ${TYPE}
   allow_failures:
-    - env: TYPE=tck-glassfish-vanilla
-    - env: TYPE=tck-glassfish-patched
+    - env: TYPE=tck-glassfish51-vanilla
+    - env: TYPE=tck-glassfish51-patched
     - env: TYPE=tck-wildfly16-vanilla
     - env: TYPE=tck-wildfly16-patched
     - env: TYPE=tck-tomee

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -41,6 +41,8 @@ elif [[ ${1} == tck-glassfish51-* ]]; then
     echo "Patching Glassfish..."
     curl -L -s -o glassfish5/glassfish/modules/jersey-cdi1x.jar \
       "https://www.dropbox.com/s/wc2ukjns388lwir/jersey-cdi1x-2.28-fix1.jar"
+    curl -L -s -o glassfish5/glassfish/modules/jersey-common.jar \
+      "https://www.dropbox.com/s/qgms27wxlpxw74x/jersey-common-2.28-fix1.jar"
   fi
 
   echo "Building Krazo..."

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -31,29 +31,31 @@ elif [ "${1}" == "glassfish-module" ]; then
   mvn -Pintegration -Dintegration.serverPort=8080 verify
   glassfish5/bin/asadmin stop-domain
 
-elif [ "${1}" == "tck-glassfish-vanilla" ]; then
+elif [[ ${1} == tck-glassfish51-* ]]; then
 
+  echo "Downloading Glassfish..."
   curl -L -s -o glassfish5.zip "${GLASSFISH_URL}"
   unzip -q glassfish5.zip
+
+  if [[ ${1} == *-patched ]]; then
+    echo "Patching Glassfish..."
+    curl -L -s -o glassfish5/glassfish/modules/jersey-cdi1x.jar \
+      "https://www.dropbox.com/s/wc2ukjns388lwir/jersey-cdi1x-2.28-fix1.jar"
+  fi
+
+  echo "Building Krazo..."
   mvn -B -V -DskipTests clean install
+
+  echo "Starting Glassfish..."
   glassfish5/bin/asadmin start-domain
   sleep 30
+
+  echo "Running TCK..."
   pushd tck
   mvn -B -V -Dtck-env=glassfish verify
   popd
-  glassfish5/bin/asadmin stop-domain
 
-elif [ "${1}" == "tck-glassfish-patched" ]; then
-
-  curl -L -s -o glassfish5.zip "${GLASSFISH_URL}"
-  unzip -q glassfish5.zip
-  curl -L -s -o glassfish5/glassfish/modules/jersey-cdi1x.jar "https://www.dropbox.com/s/wc2ukjns388lwir/jersey-cdi1x-2.28-fix1.jar"
-  mvn -B -V -DskipTests clean install
-  glassfish5/bin/asadmin start-domain
-  sleep 30
-  pushd tck
-  mvn -B -V -Dtck-env=glassfish verify
-  popd
+  echo "Stopping Glassfish..."
   glassfish5/bin/asadmin stop-domain
 
 elif [[ ${1} == tck-wildfly16-* ]]; then


### PR DESCRIPTION
This PR contains the following changes:

  * I refactored the `tests.sh` script to make it easier to maintain
  * I backported eclipse-ee4j/jersey#4103 and patched the corresponding Jersey JAR file

With this PR Krazo now passes the TCK for a patched version of Eclipse Glassfish 5.1! :beers: 