### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 # Eclipse Krazo
 
-Eclipse Krazo is an implementation of action-based MVC specifiec by MVC 1.0 (JSR-371). It builds on top of JAX-RS 
+Eclipse Krazo is an implementation of action-based MVC specified by MVC 1.0 (JSR-371). It builds on top of JAX-RS 
 and currently contains support for RESTEasy, Jersey and CXF with a well-defined SPI for other implementations.


### PR DESCRIPTION
Same as #55, which we cannot merge because of the missing Signed-off-by in the commit message.