### PR TITLE
Added fix for RESTEASY-2222 to patched wildfly profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ jobs:
   allow_failures:
     - env: TYPE=tck-glassfish51-vanilla
     - env: TYPE=tck-wildfly16-vanilla
-    - env: TYPE=tck-wildfly16-patched
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty
     - env: TYPE=glassfish-module

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -70,6 +70,9 @@ elif [[ ${1} == tck-wildfly16-* ]]; then
     echo "Patching Wildfly..."
     curl -L -s -o ./wildfly-16.0.0.Final/modules/system/layers/base/org/jboss/weld/core/main/weld-core-impl-3.1.0.Final.jar \
       "https://www.dropbox.com/s/5vm35kkkyuapcqs/weld-core-impl-3.1.0.Final-fix1.jar"
+    # https://issues.jboss.org/browse/RESTEASY-2222
+    curl -L -s -o ./wildfly-16.0.0.Final/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/resteasy-jaxrs-3.6.3.Final.jar \
+      "https://www.dropbox.com/s/erlrvci9950mpkp/resteasy-jaxrs-3.6.3.Final-fix1.jar"
   fi
 
   echo "Building Krazo..."


### PR DESCRIPTION
I added another quickfix to the `tck-wildfly16-patched`. And: Good news! The TCK passes now! :tada: 

The fix is a simple workaround for [RESTEASY-2222](https://issues.jboss.org/browse/RESTEASY-2222). Let's hope they are willing to accept a corresponding patch.

@gtudan IIRC we talked about some Wildfly specific CSRF failure at JavaLand? Do you remember any details about this failure? For some reason the TCK is green now!