### PR TITLE
Added TCK profile for Wildfly 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ jobs:
       env: TYPE=tck-wildfly16-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
+      env: TYPE=tck-wildfly17
+      script: .travis/tests.sh ${TYPE}
+    - stage: test
       env: TYPE=tck-tomee
       script: .travis/tests.sh ${TYPE}
     - stage: test

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -90,6 +90,28 @@ elif [[ ${1} == tck-wildfly16-* ]]; then
   echo "Stopping Wildfly..."
   kill $(cat wildfly.pid)
 
+elif [[ ${1} == tck-wildfly17* ]]; then
+
+  echo "Downloading Wildfly..."
+  curl -L -s -o wildfly17.zip "https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/wildfly-17.0.0.Beta1-SNAPSHOT.zip"
+  unzip wildfly17.zip
+  mv wildfly-17.0.0.Beta1-SNAPSHOT wildfly
+
+  echo "Building Krazo..."
+  mvn -B -V -DskipTests clean install
+
+  echo "Starting Wildfly..."
+  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly/bin/standalone.sh > wildfly.log 2>&1 &
+  sleep 30
+
+  echo "Running TCK..."
+  pushd tck
+  mvn -B -V -Dtck-env=wildfly verify
+  popd
+
+  echo "Stopping Wildfly..."
+  kill $(cat wildfly.pid)
+
 elif [ "${1}" == "tck-tomee" ]; then
 
   mvn -B -V -DskipTests clean install


### PR DESCRIPTION
The PR adds a new TCK profile for the upcoming Wildfly 17 release. Currently, it looks like Krazo will pass the TCK on Wildfly 17 without any additional patches. As Wildfly 17 isn't released yet, this profile uses the latest nightly builds of Wildfly.