### PR TITLE
Run TCK against Wildfly 17.0.0.Final

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -93,9 +93,9 @@ elif [[ ${1} == tck-wildfly16-* ]]; then
 elif [[ ${1} == tck-wildfly17* ]]; then
 
   echo "Downloading Wildfly..."
-  curl -L -s -o wildfly-17.0.0.Beta1.zip "https://download.jboss.org/wildfly/17.0.0.Beta1/wildfly-17.0.0.Beta1.zip"
-  unzip wildfly-17.0.0.Beta1.zip
-  mv wildfly-17.0.0.Beta1 wildfly
+  curl -L -s -o wildfly-17.0.0.Final.zip "https://download.jboss.org/wildfly/17.0.0.Final/wildfly-17.0.0.Final.zip"
+  unzip wildfly-17.0.0.Final.zip
+  mv wildfly-17.0.0.Final wildfly
 
   echo "Building Krazo..."
   mvn -B -V -DskipTests clean install

--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -93,9 +93,9 @@ elif [[ ${1} == tck-wildfly16-* ]]; then
 elif [[ ${1} == tck-wildfly17* ]]; then
 
   echo "Downloading Wildfly..."
-  curl -L -s -o wildfly17.zip "https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/wildfly-17.0.0.Beta1-SNAPSHOT.zip"
-  unzip wildfly17.zip
-  mv wildfly-17.0.0.Beta1-SNAPSHOT wildfly
+  curl -L -s -o wildfly-17.0.0.Beta1.zip "https://download.jboss.org/wildfly/17.0.0.Beta1/wildfly-17.0.0.Beta1.zip"
+  unzip wildfly-17.0.0.Beta1.zip
+  mv wildfly-17.0.0.Beta1 wildfly
 
   echo "Building Krazo..."
   mvn -B -V -DskipTests clean install


### PR DESCRIPTION
There is now an official Wildfly 17.0.0.Beta1. So we should run the TCK against this version.