### PR TITLE
Run the testsuite against the lastest WF-Release (17)

### DIFF
--- a/.travis/docker-wildfly.sh
+++ b/.travis/docker-wildfly.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
+WILDFLY_VERSION=17.0.0.Final
 set -eu
 
-docker pull jboss/wildfly:16.0.0.Final
-docker run --name=wildfly -d -p 8080:8080 -p 9990:9990 -it jboss/wildfly:16.0.0.Final /opt/jboss/wildfly/bin/standalone.sh -bmanagement 0.0.0.0 -b 0.0.0.0
+docker pull jboss/wildfly:$WILDFLY_VERSION
+docker run --name=wildfly -d -p 8080:8080 -p 9990:9990 -it jboss/wildfly:$WILDFLY_VERSION /opt/jboss/wildfly/bin/standalone.sh -bmanagement 0.0.0.0 -b 0.0.0.0
 docker exec wildfly /opt/jboss/wildfly/bin/add-user.sh admin wildfly


### PR DESCRIPTION
This updates the testsuite to the latest Wildfly version. 
The good news: no regressions \o/. Sad news: still some issues with module loading with jruby/jython.