### PR TITLE
add OWASP Dependency-Check to scan for vulnable components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ jobs:
     - stage: test
       env: TYPE=tck-liberty
       script: .travis/tests.sh ${TYPE}
+    - stage: test
+      env: TYPE=dependency-check
+      script: mvn org.owasp:dependency-check-maven:aggregate
   allow_failures:
     - env: TYPE=tck-glassfish51-vanilla
     - env: TYPE=tck-tomee

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+    <suppress>
+        <notes><![CDATA[
+            file name: dirgra-0.3.jar
+
+            This file gets detected as jruby v0.3 due to a bad pattern reported
+            in some older CVEs (listed below)
+        ]]>
+        </notes>
+        <gav regex="true">^org\.jruby:dirgra:.*$</gav>
+        <cve>CVE-2010-1330</cve>
+        <cve>CVE-2011-4838</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: jruby-stdlib-9.2.7.0.jar: jquery.js
+
+            JRuby ships a pretty old version of jquery in some dependency for Rdoc.
+            We don't generate any rdoc, so we should be fine.
+        ]]>
+        </notes>
+        <sha1>71cce71820cc47b3bd1098618d248325fcf24ddb</sha1>
+        <cve>CVE-2012-6708</cve>
+        <cve>CVE-2015-9251</cve>
+        <cve>CVE-2019-11358</cve>
+    </suppress>
+</suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"
+>
     <suppress>
         <notes><![CDATA[
             file name: dirgra-0.3.jar
@@ -24,5 +25,18 @@
         <cve>CVE-2012-6708</cve>
         <cve>CVE-2015-9251</cve>
         <cve>CVE-2019-11358</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        Most of the rendering in handlebars.java has been rewritten to Java. Only if the user wishes to write
+        util functions in javascript, those functions are executed using Nashorn and the original handlebars JS-source.
+
+        That does not mean this issue should not be fixed. We created an upsteam issue for it:
+        https://github.com/jknack/handlebars.java/issues/703
+       ]]></notes>
+        <packageUrl regex="true">pkg:javascript/handlebars\.js@4.0.4$</packageUrl>
+        <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control
+            the template
+        </vulnerabilityName>
     </suppress>
 </suppressions>

--- a/examples/validation-i18n/pom.xml
+++ b/examples/validation-i18n/pom.xml
@@ -47,6 +47,7 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>1.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/ext/asciidoc/pom.xml
+++ b/ext/asciidoc/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.7</version>
+            <version>2.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
-            <version>4.1.2</version>
+            <version>4.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/ext/pebble/pom.xml
+++ b/ext/pebble/pom.xml
@@ -30,9 +30,9 @@
     <name>Eclipse Krazo Pebble Extension</name>
     <dependencies>
         <dependency>
-            <groupId>com.mitchellbosecke</groupId>
+            <groupId>io.pebbletemplates</groupId>
             <artifactId>pebble</artifactId>
-            <version>2.4.0</version>
+            <version>3.0.10</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducer.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,41 +17,41 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Stream;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
 
 @ApplicationScoped
 public class PebbleConfigurationProducer {
 
-  @Produces
-  public Properties pebbleConfiguration() {
-    Properties pebbleProperties = loadFromFile("pebble.properties");
+    @Produces
+    public Properties pebbleConfiguration() {
+        Properties pebbleProperties = loadFromFile("pebble.properties");
 
-    Stream.of(PebbleProperty.values())
-        .forEach(property
-            -> property.systemPropertyValue().ifPresent(value -> pebbleProperties.put(property.key(), value))
-        );
+        Stream.of(PebbleProperty.values())
+            .forEach(property
+                -> property.systemPropertyValue().ifPresent(value -> pebbleProperties.put(property.key(), value))
+            );
 
-    return pebbleProperties;
-  }
-
-  public Properties loadFromFile(String fileName) {
-    Properties props = new Properties();
-
-    try (InputStream config = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
-      if (Objects.nonNull(config)) {
-        props.load(config);
-      }
-    } catch (IOException e) {
-      // ignore exception
+        return pebbleProperties;
     }
 
-    return props;
-  }
+    public Properties loadFromFile(String fileName) {
+        Properties props = new Properties();
+
+        try (InputStream config = Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName)) {
+            if (Objects.nonNull(config)) {
+                props.load(config);
+            }
+        } catch (IOException e) {
+            // ignore exception
+        }
+
+        return props;
+    }
 
 }

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducer.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,112 +17,101 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import com.google.common.cache.CacheBuilder;
 import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.extension.Extension;
 import com.mitchellbosecke.pebble.extension.escaper.EscapingStrategy;
 import com.mitchellbosecke.pebble.loader.ServletLoader;
+import org.eclipse.krazo.engine.ViewEngineConfig;
 
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.servlet.ServletContext;
-
-import org.eclipse.krazo.engine.ViewEngineConfig;
-
 public class PebbleEngineProducer {
 
-  private Properties pebbleConfiguration;
-  private ServletContext servletContext;
+    private Properties pebbleConfiguration;
+    private ServletContext servletContext;
 
-  @Inject
-  public PebbleEngineProducer(Properties pebbleConfiguration, ServletContext servletContext) {
-    this.pebbleConfiguration = pebbleConfiguration;
-    this.servletContext = servletContext;
-  }
+    @Inject
+    public PebbleEngineProducer(Properties pebbleConfiguration, ServletContext servletContext) {
+        this.pebbleConfiguration = pebbleConfiguration;
+        this.servletContext = servletContext;
+    }
 
-  @Produces
-  @ViewEngineConfig
-  public PebbleEngine pebbleEngine() {
-    PebbleEngine.Builder engine = new PebbleEngine.Builder();
+    @Produces
+    @ViewEngineConfig
+    public PebbleEngine pebbleEngine() {
+        PebbleEngine.Builder engine = new PebbleEngine.Builder();
 
-    pebbleConfiguration
-        .entrySet()
-        .stream()
-        .filter(e -> String.valueOf(e.getValue()).trim().length() > 0)
-        .forEach((e) -> {
+        pebbleConfiguration
+            .entrySet()
+            .stream()
+            .filter(e -> String.valueOf(e.getValue()).trim().length() > 0)
+            .forEach((e) -> {
 
-          String val = String.valueOf(e.getValue());
+                String val = String.valueOf(e.getValue());
 
-          switch (PebbleProperty.fromKey(String.valueOf(e.getKey()))) {
-            case AUTO_ESCAPING:
-              engine.autoEscaping(Boolean.valueOf(val));
-              break;
-            case CACHE_ACTIVE:
-              engine.cacheActive(Boolean.valueOf(val));
-              break;
-            case ESCAPING_STRATEGY:
-              try {
-                String escapingStrategyKey = "userDefinedEscapingStrategy";
-                engine.addEscapingStrategy(escapingStrategyKey, (EscapingStrategy) Class.forName(val).newInstance());
-                engine.defaultEscapingStrategy(escapingStrategyKey);
-              } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
-                String msg = String.format("Pebble initialization error: Could not register escaping strategy '%s' of type %s", String.valueOf(e.getKey()), val);
-                throw new IllegalArgumentException(msg, ex);
-              }
-              break;
-            case DEFAULT_LOCALE:
-              engine.defaultLocale(Locale.forLanguageTag(val));
-              break;
-            case NEW_LINE_TRIMMING:
-              engine.newLineTrimming(Boolean.valueOf(val));
-              break;
-            case STRICT_VARIABLES:
-              engine.strictVariables(Boolean.valueOf(val));
-              break;
-            case EXECUTOR_SERVICE:
-              try {
-                engine.executorService((ExecutorService) Class.forName(val).newInstance());
-              } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
-                String msg = String.format("Pebble initialization error: Could not register executor service type %s", val);
-                throw new IllegalArgumentException(msg, ex);
-              }
-              break;
-            case EXTENSION:
-              String[] extensions = val.split(",");
+                switch (PebbleProperty.fromKey(String.valueOf(e.getKey()))) {
+                    case AUTO_ESCAPING:
+                        engine.autoEscaping(Boolean.valueOf(val));
+                        break;
+                    case CACHE_ACTIVE:
+                        engine.cacheActive(Boolean.valueOf(val));
+                        break;
+                    case ESCAPING_STRATEGY:
+                        try {
+                            String escapingStrategyKey = "userDefinedEscapingStrategy";
+                            engine.addEscapingStrategy(escapingStrategyKey, (EscapingStrategy) Class.forName(val).newInstance());
+                            engine.defaultEscapingStrategy(escapingStrategyKey);
+                        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+                            String msg = String.format("Pebble initialization error: Could not register escaping strategy '%s' of type %s", String.valueOf(e.getKey()), val);
+                            throw new IllegalArgumentException(msg, ex);
+                        }
+                        break;
+                    case DEFAULT_LOCALE:
+                        engine.defaultLocale(Locale.forLanguageTag(val));
+                        break;
+                    case NEW_LINE_TRIMMING:
+                        engine.newLineTrimming(Boolean.valueOf(val));
+                        break;
+                    case STRICT_VARIABLES:
+                        engine.strictVariables(Boolean.valueOf(val));
+                        break;
+                    case EXECUTOR_SERVICE:
+                        try {
+                            engine.executorService((ExecutorService) Class.forName(val).newInstance());
+                        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+                            String msg = String.format("Pebble initialization error: Could not register executor service type %s", val);
+                            throw new IllegalArgumentException(msg, ex);
+                        }
+                        break;
+                    case EXTENSION:
+                        String[] extensions = val.split(",");
 
-              Extension[] extensionArray = Stream.of(extensions)
-                  .map(clazzName -> {
-                    try {
-                      return (Extension) Class.forName(clazzName.trim()).newInstance();
-                    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
-                      String msg = String.format("Pebble initialization error: Could not register extension of type %s", clazzName);
-                      throw new IllegalArgumentException(msg, ex);
-                    }
-                  }).toArray(Extension[]::new);
+                        Extension[] extensionArray = Stream.of(extensions)
+                            .map(clazzName -> {
+                                try {
+                                    return (Extension) Class.forName(clazzName.trim()).newInstance();
+                                } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+                                    String msg = String.format("Pebble initialization error: Could not register extension of type %s", clazzName);
+                                    throw new IllegalArgumentException(msg, ex);
+                                }
+                            }).toArray(Extension[]::new);
 
-              engine.extension(extensionArray);
-              break;
-            case TAG_CACHE_MAX:
-              engine.tagCache(CacheBuilder.newBuilder().maximumSize(Integer.valueOf(val)).build());
-              break;
-            case TEMPLATE_CACHE_MAX:
-              engine.templateCache(CacheBuilder.newBuilder().maximumSize(Integer.valueOf(val)).build());
-              break;
-            case UNKNOWN:
-              break;
-            default:
-              break;
-          }
-        });
+                        engine.extension(extensionArray);
+                        break;
+                    default:
+                        break;
+                }
+            });
 
-    engine.loader(new ServletLoader(servletContext));
+        engine.loader(new ServletLoader(servletContext));
 
-    return engine.build();
-  }
+        return engine.build();
+    }
 
 }

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleProperty.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,37 +22,35 @@ import java.util.stream.Stream;
 
 public enum PebbleProperty {
 
-  AUTO_ESCAPING("autoEscaping"),
-  CACHE_ACTIVE("cacheActive"),
-  ESCAPING_STRATEGY("escapingStrategy"),
-  DEFAULT_LOCALE("defaultLocale"),
-  NEW_LINE_TRIMMING("newLineTrimming"),
-  STRICT_VARIABLES("strictVariables"),
-  EXECUTOR_SERVICE("executorService"),
-  EXTENSION("extension"),
-  TAG_CACHE_MAX("tagCacheMax"),
-  TEMPLATE_CACHE_MAX("templateCacheMax"),
-  UNKNOWN("unknown");
+    AUTO_ESCAPING("autoEscaping"),
+    CACHE_ACTIVE("cacheActive"),
+    ESCAPING_STRATEGY("escapingStrategy"),
+    DEFAULT_LOCALE("defaultLocale"),
+    NEW_LINE_TRIMMING("newLineTrimming"),
+    STRICT_VARIABLES("strictVariables"),
+    EXECUTOR_SERVICE("executorService"),
+    EXTENSION("extension"),
+    UNKNOWN("unknown");
 
-  private static final String GROUP_PREFIX = "org.eclipse.krazo.ext.pebble.";
-  private final String key;
+    private static final String GROUP_PREFIX = "org.eclipse.krazo.ext.pebble.";
+    private final String key;
 
-  private PebbleProperty(String key) {
-    this.key = key;
-  }
+    PebbleProperty(String key) {
+        this.key = key;
+    }
 
-  public String key() {
-    return GROUP_PREFIX + this.key;
-  }
+    public String key() {
+        return GROUP_PREFIX + this.key;
+    }
 
-  public static PebbleProperty fromKey(String key) {
-    return Stream.of(PebbleProperty.values())
-        .filter(property -> property.key().equals(key))
-        .findFirst()
-        .orElse(UNKNOWN);
-  }
+    public static PebbleProperty fromKey(String key) {
+        return Stream.of(PebbleProperty.values())
+            .filter(property -> property.key().equals(key))
+            .findFirst()
+            .orElse(UNKNOWN);
+    }
 
-  public Optional<String> systemPropertyValue() {
-    return Optional.ofNullable(System.getProperty(this.key()));
-  }
+    public Optional<String> systemPropertyValue() {
+        return Optional.ofNullable(System.getProperty(this.key()));
+    }
 }

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleViewEngine.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleViewEngine.java
@@ -21,22 +21,21 @@ import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.eclipse.krazo.engine.ViewEngineBase;
+import org.eclipse.krazo.engine.ViewEngineConfig;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-
-import org.eclipse.krazo.engine.ViewEngineConfig;
 
 /**
  * @see <a href="http://www.mitchellbosecke.com/pebble/home">Pebble</a>

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomEscapingStrategy.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomEscapingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import com.mitchellbosecke.pebble.extension.escaper.EscapingStrategy;
 
 public class CustomEscapingStrategy implements EscapingStrategy {
 
-  @Override
-  public String escape(String string) {
-    return string;
-  }
+    @Override
+    public String escape(String string) {
+        return string;
+    }
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExecutorService.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,78 +19,73 @@ package org.eclipse.krazo.ext.pebble;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 public class CustomExecutorService implements ExecutorService {
 
-  @Override
-  public void shutdown() {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public List<Runnable> shutdownNow() {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public boolean isShutdown() {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public boolean isShutdown() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public boolean isTerminated() {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public boolean isTerminated() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> Future<T> submit(Callable<T> task) {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> Future<T> submit(Runnable task, T result) {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public Future<?> submit(Runnable task) {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public Future<?> submit(Runnable task) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
-  @Override
-  public void execute(Runnable command) {
-    throw new UnsupportedOperationException("Not supported yet.");
-  }
+    @Override
+    public void execute(Runnable command) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionOne.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,58 +17,61 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import com.mitchellbosecke.pebble.extension.Extension;
-import com.mitchellbosecke.pebble.extension.Filter;
-import com.mitchellbosecke.pebble.extension.Function;
-import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
-import com.mitchellbosecke.pebble.extension.Test;
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.extension.*;
 import com.mitchellbosecke.pebble.operator.BinaryOperator;
 import com.mitchellbosecke.pebble.operator.UnaryOperator;
 import com.mitchellbosecke.pebble.tokenParser.TokenParser;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class CustomExtensionOne implements Extension {
 
-  @Override
-  public Map<String, Filter> getFilters() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Filter> getFilters() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public Map<String, Test> getTests() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Test> getTests() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public Map<String, Function> getFunctions() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Function> getFunctions() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public List<TokenParser> getTokenParsers() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<TokenParser> getTokenParsers() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public List<BinaryOperator> getBinaryOperators() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<BinaryOperator> getBinaryOperators() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public List<UnaryOperator> getUnaryOperators() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<UnaryOperator> getUnaryOperators() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public Map<String, Object> getGlobalVariables() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Object> getGlobalVariables() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public List<NodeVisitorFactory> getNodeVisitors() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<NodeVisitorFactory> getNodeVisitors() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public List<AttributeResolver> getAttributeResolver() {
+        return Collections.EMPTY_LIST;
+    }
 
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionTwo.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionTwo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,57 +17,60 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import com.mitchellbosecke.pebble.extension.Extension;
-import com.mitchellbosecke.pebble.extension.Filter;
-import com.mitchellbosecke.pebble.extension.Function;
-import com.mitchellbosecke.pebble.extension.NodeVisitorFactory;
-import com.mitchellbosecke.pebble.extension.Test;
+import com.mitchellbosecke.pebble.attributes.AttributeResolver;
+import com.mitchellbosecke.pebble.extension.*;
 import com.mitchellbosecke.pebble.operator.BinaryOperator;
 import com.mitchellbosecke.pebble.operator.UnaryOperator;
 import com.mitchellbosecke.pebble.tokenParser.TokenParser;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class CustomExtensionTwo implements Extension {
 
-  @Override
-  public Map<String, Filter> getFilters() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Filter> getFilters() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public Map<String, Test> getTests() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Test> getTests() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public Map<String, Function> getFunctions() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Function> getFunctions() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public List<TokenParser> getTokenParsers() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<TokenParser> getTokenParsers() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public List<BinaryOperator> getBinaryOperators() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<BinaryOperator> getBinaryOperators() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public List<UnaryOperator> getUnaryOperators() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<UnaryOperator> getUnaryOperators() {
+        return Collections.EMPTY_LIST;
+    }
 
-  @Override
-  public Map<String, Object> getGlobalVariables() {
-    return Collections.EMPTY_MAP;
-  }
+    @Override
+    public Map<String, Object> getGlobalVariables() {
+        return Collections.EMPTY_MAP;
+    }
 
-  @Override
-  public List<NodeVisitorFactory> getNodeVisitors() {
-    return Collections.EMPTY_LIST;
-  }
+    @Override
+    public List<NodeVisitorFactory> getNodeVisitors() {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public List<AttributeResolver> getAttributeResolver() {
+        return Collections.EMPTY_LIST;
+    }
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducerTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,53 +17,54 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import java.util.Properties;
-
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+
 public class PebbleConfigurationProducerTest {
 
-  PebbleConfigurationProducer pebbleConfigurationProducer;
+    PebbleConfigurationProducer pebbleConfigurationProducer;
 
-  @Before
-  public void setup() {
-    pebbleConfigurationProducer = new PebbleConfigurationProducer();
-    System.clearProperty(PebbleProperty.AUTO_ESCAPING.key());
-  }
+    @Before
+    public void setup() {
+        pebbleConfigurationProducer = new PebbleConfigurationProducer();
+        System.clearProperty(PebbleProperty.AUTO_ESCAPING.key());
+    }
 
-  @Test
-  public void shouldReturnEmptyPropertiesForNonExistingPropertiesFile() {
-    Properties pebbleConfiguration = pebbleConfigurationProducer.loadFromFile("unexisting.properties");
+    @Test
+    public void shouldReturnEmptyPropertiesForNonExistingPropertiesFile() {
+        Properties pebbleConfiguration = pebbleConfigurationProducer.loadFromFile("unexisting.properties");
 
-    assertNotNull(pebbleConfiguration);
-    assertTrue(pebbleConfiguration.isEmpty());
-  }
+        assertNotNull(pebbleConfiguration);
+        assertTrue(pebbleConfiguration.isEmpty());
+    }
 
-  @Test
-  public void shouldLoadPebbleConfigurationPropertiesFromFile() {
-    Properties pebbleConfiguration = pebbleConfigurationProducer.loadFromFile("pebble.properties");
+    @Test
+    public void shouldLoadPebbleConfigurationPropertiesFromFile() {
+        Properties pebbleConfiguration = pebbleConfigurationProducer.loadFromFile("pebble.properties");
 
-    assertNotNull(pebbleConfiguration);
-    assertEquals(pebbleConfiguration.getProperty("org.eclipse.krazo.ext.pebble.autoEscaping"), "true");
-  }
+        assertNotNull(pebbleConfiguration);
+        assertEquals(pebbleConfiguration.getProperty("org.eclipse.krazo.ext.pebble.autoEscaping"), "true");
+    }
 
-  @Test
-  public void shouldReturnPebbleConfiguration() {
-    Properties pebbleConfiguration = pebbleConfigurationProducer.pebbleConfiguration();
+    @Test
+    public void shouldReturnPebbleConfiguration() {
+        Properties pebbleConfiguration = pebbleConfigurationProducer.pebbleConfiguration();
 
-    assertNotNull(pebbleConfiguration);
-    assertEquals(pebbleConfiguration.getProperty("org.eclipse.krazo.ext.pebble.autoEscaping"), "true");
-  }
+        assertNotNull(pebbleConfiguration);
+        assertEquals(pebbleConfiguration.getProperty("org.eclipse.krazo.ext.pebble.autoEscaping"), "true");
+    }
 
-  @Test
-  public void systemPropertyShouldHaveHigherPriorityThanTheOneFromPropertyFile() {
-    System.setProperty(PebbleProperty.AUTO_ESCAPING.key(), "false-override");
+    @Test
+    public void systemPropertyShouldHaveHigherPriorityThanTheOneFromPropertyFile() {
+        System.setProperty(PebbleProperty.AUTO_ESCAPING.key(), "false-override");
 
-    Properties pebbleConfiguration = pebbleConfigurationProducer.pebbleConfiguration();
+        Properties pebbleConfiguration = pebbleConfigurationProducer.pebbleConfiguration();
 
-    assertNotNull(pebbleConfiguration);
-    assertEquals(pebbleConfiguration.getProperty(PebbleProperty.AUTO_ESCAPING.key()), "false-override");
-  }
+        assertNotNull(pebbleConfiguration);
+        assertEquals(pebbleConfiguration.getProperty(PebbleProperty.AUTO_ESCAPING.key()), "false-override");
+    }
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducerTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,153 +17,96 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import com.google.common.cache.Cache;
 import com.mitchellbosecke.pebble.PebbleEngine;
-import com.mitchellbosecke.pebble.cache.BaseTagCacheKey;
 import com.mitchellbosecke.pebble.extension.escaper.EscapeFilter;
 import com.mitchellbosecke.pebble.loader.ServletLoader;
-import com.mitchellbosecke.pebble.template.PebbleTemplate;
-import com.mitchellbosecke.pebble.template.PebbleTemplateImpl;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
 import java.util.Properties;
-import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
 
 public class PebbleEngineProducerTest {
 
-  Properties properties;
-  PebbleEngineProducer pebbleEngineProducer;
+    Properties properties;
+    PebbleEngineProducer pebbleEngineProducer;
 
-  @Before
-  public void setup() {
-    properties = new Properties();
-    pebbleEngineProducer = new PebbleEngineProducer(properties, null);
-  }
+    @Before
+    public void setup() {
+        properties = new Properties();
+        pebbleEngineProducer = new PebbleEngineProducer(properties, null);
+    }
 
-  @Test
-  public void shouldCreateAnInstanceOfPebbleEngine() {
-    assertTrue(pebbleEngineProducer.pebbleEngine() instanceof PebbleEngine);
-  }
+    @Test
+    public void shouldCreateAnInstanceOfPebbleEngine() {
+        assertNotNull(pebbleEngineProducer.pebbleEngine());
+    }
 
-  @Test
-  public void shouldIgnoreEmptyValueAndUseDefaultValue() {
-    properties.put(PebbleProperty.TAG_CACHE_MAX.key(), "");
-    properties.put(PebbleProperty.CACHE_ACTIVE.key(), "true");
+    @Test
+    public void shouldUseServletContextLoader() {
+        assertTrue(pebbleEngineProducer.pebbleEngine().getLoader() instanceof ServletLoader);
+    }
 
-    Cache<BaseTagCacheKey, Object> tagCache = pebbleEngineProducer.pebbleEngine().getTagCache();
+    @Test
+    public void shouldSetCorrectLocale() {
+        properties.put(PebbleProperty.DEFAULT_LOCALE.key(), "de");
 
-    IntStream.range(0, 250).forEach(i -> tagCache.put(new BaseTagCacheKey(String.valueOf(i)) {
-    }, i));
+        assertEquals(Locale.GERMAN, pebbleEngineProducer.pebbleEngine().getDefaultLocale());
+    }
 
-    assertEquals(200, tagCache.size());
-  }
+    @Test
+    public void shouldCorrectlySetStrictVariables() {
+        properties.put(PebbleProperty.STRICT_VARIABLES.key(), "true");
 
-  @Test
-  public void shouldUseServletContextLoader() {
-    assertTrue(pebbleEngineProducer.pebbleEngine().getLoader() instanceof ServletLoader);
-  }
+        assertTrue(pebbleEngineProducer.pebbleEngine().isStrictVariables());
 
-  @Test
-  public void shouldSetCorrectLocale() {
-    properties.put(PebbleProperty.DEFAULT_LOCALE.key(), "de");
+        properties.put(PebbleProperty.STRICT_VARIABLES.key(), "false");
 
-    assertEquals(Locale.GERMAN, pebbleEngineProducer.pebbleEngine().getDefaultLocale());
-  }
+        assertFalse(pebbleEngineProducer.pebbleEngine().isStrictVariables());
+    }
 
-  @Test
-  public void shouldCorrectlySetTagCache() {
-    properties.put(PebbleProperty.TAG_CACHE_MAX.key(), "123");
-    Cache<BaseTagCacheKey, Object> tagCache = pebbleEngineProducer.pebbleEngine().getTagCache();
+    @Test
+    public void shouldCorrectlySetExecutorService() {
+        properties.put(PebbleProperty.EXECUTOR_SERVICE.key(), CustomExecutorService.class.getCanonicalName());
 
-    IntStream.range(0, 200).forEach(i -> tagCache.put(new BaseTagCacheKey(String.valueOf(i)) {
-    }, i));
+        assertTrue(pebbleEngineProducer.pebbleEngine().getExecutorService() instanceof CustomExecutorService);
+    }
 
-    assertEquals(123, tagCache.size());
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhileSettingExecutorService() {
+        properties.put(PebbleProperty.EXECUTOR_SERVICE.key(), "org.dummy.DummyExecutorService");
 
-  @Test
-  public void shouldCorrectlySetTemplateCache() {
-    properties.put(PebbleProperty.TEMPLATE_CACHE_MAX.key(), "126");
-    Cache<Object, PebbleTemplate> templateCache = pebbleEngineProducer.pebbleEngine().getTemplateCache();
+        pebbleEngineProducer.pebbleEngine();
+    }
 
-    IntStream.range(0, 200).forEach(i -> templateCache.put(i, new PebbleTemplateImpl(null, null, String.valueOf(i))));
+    @Test
+    public void shouldCorrectlySetExtensions() {
+        properties.put(PebbleProperty.EXTENSION.key(), String.format("%s,%s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
 
-    assertEquals(126, templateCache.size());
-  }
+        pebbleEngineProducer.pebbleEngine();
 
-  @Test
-  public void shouldNotSetCachesWhenCachingIsOff() {
-    properties.put(PebbleProperty.CACHE_ACTIVE.key(), "false");
-    properties.put(PebbleProperty.TAG_CACHE_MAX.key(), "123");
-    properties.put(PebbleProperty.TEMPLATE_CACHE_MAX.key(), "126");
+        properties.put(PebbleProperty.EXTENSION.key(), String.format("%s , %s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
 
-    Cache<BaseTagCacheKey, Object> tagCache = pebbleEngineProducer.pebbleEngine().getTagCache();
-    IntStream.range(0, 200).forEach(i -> tagCache.put(new BaseTagCacheKey(String.valueOf(i)) {
-    }, i));
+        pebbleEngineProducer.pebbleEngine();
+    }
 
-    Cache<Object, PebbleTemplate> templateCache = pebbleEngineProducer.pebbleEngine().getTemplateCache();
-    IntStream.range(0, 200).forEach(i -> templateCache.put(i, new PebbleTemplateImpl(null, null, String.valueOf(i))));
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhileSettingExtensions() {
+        properties.put(PebbleProperty.EXTENSION.key(), String.format("%s-%s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
 
-    assertEquals(0, tagCache.size());
-    assertEquals(0, templateCache.size());
-  }
+        pebbleEngineProducer.pebbleEngine();
+    }
 
-  @Test
-  public void shouldCorrectlySetStrictVariables() {
-    properties.put(PebbleProperty.STRICT_VARIABLES.key(), "true");
+    @Test
+    public void shouldCorrectlySetEscapingStrategy() {
+        properties.put(PebbleProperty.ESCAPING_STRATEGY.key(), CustomEscapingStrategy.class.getCanonicalName());
 
-    assertTrue(pebbleEngineProducer.pebbleEngine().isStrictVariables());
+        PebbleEngine pebbleEngine = pebbleEngineProducer.pebbleEngine();
+        EscapeFilter ef = (EscapeFilter) pebbleEngine.getExtensionRegistry().getFilter("escape");
 
-    properties.put(PebbleProperty.STRICT_VARIABLES.key(), "false");
-
-    assertFalse(pebbleEngineProducer.pebbleEngine().isStrictVariables());
-  }
-
-  @Test
-  public void shouldCorrectlySetExecutorService() {
-    properties.put(PebbleProperty.EXECUTOR_SERVICE.key(), CustomExecutorService.class.getCanonicalName());
-
-    assertTrue(pebbleEngineProducer.pebbleEngine().getExecutorService() instanceof CustomExecutorService);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowExceptionWhileSettingExecutorService() {
-    properties.put(PebbleProperty.EXECUTOR_SERVICE.key(), "org.dummy.DummyExecutorService");
-
-    pebbleEngineProducer.pebbleEngine();
-  }
-
-  @Test
-  public void shouldCorrectlySetExtensions() {
-    properties.put(PebbleProperty.EXTENSION.key(), String.format("%s,%s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
-
-    pebbleEngineProducer.pebbleEngine();
-
-    properties.put(PebbleProperty.EXTENSION.key(), String.format("%s , %s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
-
-    pebbleEngineProducer.pebbleEngine();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowExceptionWhileSettingExtensions() {
-    properties.put(PebbleProperty.EXTENSION.key(), String.format("%s-%s", CustomExtensionOne.class.getCanonicalName(), CustomExtensionTwo.class.getCanonicalName()));
-
-    pebbleEngineProducer.pebbleEngine();
-  }
-
-  @Test
-  public void shouldCorrectlySetEscapingStrategy() {
-    properties.put(PebbleProperty.ESCAPING_STRATEGY.key(), CustomEscapingStrategy.class.getCanonicalName());
-
-    PebbleEngine pebbleEngine = pebbleEngineProducer.pebbleEngine();
-    EscapeFilter ef = (EscapeFilter) pebbleEngine.getExtensionRegistry().getFilter("escape");
-
-    assertEquals(ef.getDefaultStrategy(), "userDefinedEscapingStrategy");
-  }
+        assertEquals(ef.getDefaultStrategy(), "userDefinedEscapingStrategy");
+    }
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebblePropertyTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebblePropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,34 +17,35 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
+import org.junit.Test;
+
 import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
-import org.junit.Test;
 
 public class PebblePropertyTest {
 
-  @Test
-  public void propertyKeyShouldStartWithGroupPrefix() {
-    final String groupPrefix = "org.eclipse.krazo.ext.pebble.";
+    @Test
+    public void propertyKeyShouldStartWithGroupPrefix() {
+        final String groupPrefix = "org.eclipse.krazo.ext.pebble.";
 
-    Stream.of(PebbleProperty.values()).forEach(property -> {
-      assertTrue(property.key().startsWith(groupPrefix));
-    });
-  }
+        Stream.of(PebbleProperty.values()).forEach(property -> {
+            assertTrue(property.key().startsWith(groupPrefix));
+        });
+    }
 
-  @Test
-  public void shouldResolvePebblePropertyFromStringKey() {
-    Stream.of(PebbleProperty.values()).forEach(property -> {
-      assertEquals(property, PebbleProperty.fromKey(property.key()));
-    });
-  }
+    @Test
+    public void shouldResolvePebblePropertyFromStringKey() {
+        Stream.of(PebbleProperty.values()).forEach(property -> {
+            assertEquals(property, PebbleProperty.fromKey(property.key()));
+        });
+    }
 
-  @Test
-  public void shouldReturnSystemPropertyValueAsOptional() {
-    System.setProperty(PebbleProperty.STRICT_VARIABLES.key(), "false");
+    @Test
+    public void shouldReturnSystemPropertyValueAsOptional() {
+        System.setProperty(PebbleProperty.STRICT_VARIABLES.key(), "false");
 
-    assertEquals("false", PebbleProperty.STRICT_VARIABLES.systemPropertyValue().get());
-    assertFalse(PebbleProperty.NEW_LINE_TRIMMING.systemPropertyValue().isPresent());
-  }
+        assertEquals("false", PebbleProperty.STRICT_VARIABLES.systemPropertyValue().get());
+        assertFalse(PebbleProperty.NEW_LINE_TRIMMING.systemPropertyValue().isPresent());
+    }
 }

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleViewEngineTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleViewEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright © 2017, 2019 Ivar Grimstad
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,18 @@
  */
 package org.eclipse.krazo.ext.pebble;
 
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PebbleViewEngineTest {
 
-  @Test
-  public void shouldSupportOnlyFilesWithExtensionPeb() {
-    PebbleViewEngine engine = new PebbleViewEngine(null);
+    @Test
+    public void shouldSupportOnlyFilesWithExtensionPeb() {
+        PebbleViewEngine engine = new PebbleViewEngine(null);
 
-    assertTrue(engine.supports("view.peb"));
-    assertFalse(engine.supports("view.txt"));
-  }
+        assertTrue(engine.supports("view.peb"));
+        assertFalse(engine.supports("view.txt"));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
                             <exclude>org.jboss.shrinkwrap.resolver:*</exclude>
                         </excludes>
                         <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
+                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <!-- skip dependencies provided by the application servers -->
                         <skipProvidedScope>true</skipProvidedScope>
+                        <excludes>
+                            <!-- Shrinkwrap includes a lot of the dependencies and some of them are quiet old.
+                            We don't ship it, but only use it in the tck. So we won't report those libs as vulnerable -->
+                            <exclude>org.jboss.shrinkwrap.resolver:*</exclude>
+                        </excludes>
+                        <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,19 @@
                     </configuration>
                 </plugin>
 
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>5.0.0</version>
+                    <configuration>
+                        <!-- Some dependencies ship dlls for native bindings.
+                        This avoids warnings about dotnet not being installed -->
+                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <!-- skip dependencies provided by the application servers -->
+                        <skipProvidedScope>true</skipProvidedScope>
+                    </configuration>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.0.0</version>
+                    <version>5.1.0</version>
                     <configuration>
                         <!-- Some dependencies ship dlls for native bindings.
                         This avoids warnings about dotnet not being installed -->

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,6 @@
                             <exclude>org.jboss.shrinkwrap.resolver:*</exclude>
                         </excludes>
                         <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,10 @@
                             <exclude>org.jboss.shrinkwrap.resolver:*</exclude>
                         </excludes>
                         <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
-                        <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+                        <!-- We allow the build to pass with vulnerabilities below HIGH or MEDIUM.
+                        We should lower this value to MEDIUM (4) once all issues in upstream libraries
+                        (especially from the ext-package) have been resolved. -->
+                        <failBuildOnCVSS>7</failBuildOnCVSS>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Some of the dependencies used in the ext packages got a little dated and have known vulnerabilities.
This adds the [OWASP Dependency Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) as stage to Travis to help us monitor the issues. The plugin also generates a nice HTML report under target/ in the project base dir that helps to understand what's wrong and where the broken dependencies came from.

I started fixing some of the issues by updating the dependencies. The testsuite looks good (yay!) but I'm pretty sure we need to go through some paperwork to get the new versions approved by eclipse.

For comparison: here's the test before those fixes: https://travis-ci.org/gtudan/krazo/jobs/546367007

There are still some issues left in these extensions, so I filed upstream issues for them:

* Jtwig: jtwig/jtwig#375
* Handlebars: jknack/handlebars.java#703

We could wait for those issues to get fixed and update, or mark the test as allowed to fail. I guess it's a matter or what happens first: the fixes or the eclipse paperwork ;-)  

To summarize, these are the CQs that need to pass before we can merge:

- [x] Pebble: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20263
- [x] Aciidoctor: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20262
- [x] the dependency check itself: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20283