### PR TITLE
Run testsuite against TomEE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ jobs:
       before_script: .travis/docker-payara.sh
       script: mvn -P${TYPE} --projects testsuite clean verify
     - stage: test
+      env: TYPE=testsuite-tomee
+      before_script: .travis/docker-tomee.sh
+      script: mvn -P${TYPE} --projects testsuite clean verify
+    - stage: test
       env: TYPE=tck-glassfish51-vanilla
       script: .travis/tests.sh ${TYPE}
     - stage: test
@@ -43,4 +47,5 @@ jobs:
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty
     - env: TYPE=testsuite-wildfly
+    - env: TYPE=testsuite-tomee
     - env: TYPE=glassfish-module

--- a/.travis/docker-tomee.sh
+++ b/.travis/docker-tomee.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+set -eu
+
+TOMEE_VERSION=8-jre-7.1.0-plus
+
+docker pull tomee:${TOMEE_VERSION}
+docker run --name=tomee -d \
+    -p 8080:8080 \
+    -e CATALINA_OPTS="\
+        -Dtomee.serialization.class.blacklist=- \
+        -Dtomee.remote.support=true \
+        -Dopenejb.system.apps=true" \
+    tomee:${TOMEE_VERSION}

--- a/.travis/docker-tomee.sh
+++ b/.travis/docker-tomee.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-TOMEE_VERSION=8-jre-7.1.0-plus
+TOMEE_VERSION=11-jre-8.0.0-M3-plus
 
 docker pull tomee:${TOMEE_VERSION}
 docker run --name=tomee -d \

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -319,5 +319,41 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>testsuite-tomee</id>
+
+            <properties>
+                <skipITs>false</skipITs>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.tomee</groupId>
+                    <artifactId>arquillian-tomee-remote</artifactId>
+                    <version>7.1.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.krazo</groupId>
+                    <artifactId>krazo-cxf</artifactId>
+                    <version>${project.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                            <systemProperties>
+                                <arquillian.launch>tomee</arquillian.launch>
+                                <testsuite.profile>testsuite-tomee</testsuite.profile>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -330,7 +330,7 @@
                 <dependency>
                     <groupId>org.apache.tomee</groupId>
                     <artifactId>arquillian-tomee-remote</artifactId>
-                    <version>7.1.1</version>
+                    <version>8.0.0-M3</version>
                 </dependency>
                 <dependency>
                     <groupId>org.eclipse.krazo</groupId>

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -23,7 +23,7 @@
         http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0" />
+    <defaultProtocol type="Servlet 3.0"/>
 
     <extension qualifier="webdriver">
         <property name="browser">htmlunit</property>
@@ -44,4 +44,11 @@
         </configuration>
     </container>
 
+    <container qualifier="tomee">
+        <configuration>
+            <property name="deployerProperties">
+                openejb.deployer.binaries.use=true
+            </property>
+        </configuration>
+    </container>
 </arquillian>


### PR DESCRIPTION
Still working on improving the testsuite and making sure our extensions work with different providers.
This runs the integration-tests from the testuite against TomEE 7, so we get some coverage for CXF.

There are failures, but only two. I'm a pleasantly surprised :-)

* The Pebble Ext doesn't work - I will try to look into it.
* The hidden forms IT fails when using the patch-method. I'll file an issue for it. @erdlet could you please take a look? 