### PR TITLE
Run Travis build with javadoc generation enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 jobs:
   include:
     - stage: build
-      script: mvn -B -V -DskipTests clean install
+      script: mvn -B -V -DskipTests -DperformRelease -Dgpg.skip clean install
     - stage: test
       env: TYPE=glassfish-module
       script: .travis/tests.sh ${TYPE}

--- a/core/src/main/java/org/eclipse/krazo/forms/HiddenMethodFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/forms/HiddenMethodFilter.java
@@ -44,6 +44,8 @@ import org.eclipse.krazo.util.ServiceLoaders;
  *
  * <p>
  * Example:
+ * </p>
+ *
  * <pre>
  * {@code
  *    <form action="/example" method="post">
@@ -52,7 +54,6 @@ import org.eclipse.krazo.util.ServiceLoaders;
  *    </form>
  * }
  * </pre>
- * </p>
  *
  * @author Tobias Erdle
  */


### PR DESCRIPTION
I just noticed that our [nighly build](https://jenkins.eclipse.org/krazo/job/nightly/) running on Eclipse Jenkins was broken for quite some time. The issue was that running the build with the release profile (which creates javadocs, source code attachments, etc.) failed because one class contained invalid HTML in the API docs.

This PR fixes the HTML issue and updates the Travis build to activate the release profile for the build (excluding the GPG signature).