### PR TITLE
Updated TCK module to run TCK against TomEE 8.0.0-M3

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -194,7 +194,7 @@
                 </property>
             </activation>
             <properties>
-                <tomee.version>8.0.0-M2</tomee.version>
+                <tomee.version>8.0.0-M3</tomee.version>
                 <tomee.classifier>webprofile</tomee.classifier>
             </properties>
             <build>


### PR DESCRIPTION
Now as we have an [approved CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20315) for TomEE 8.0.0-M3, we should also run the TCK against this version.