### PR TITLE
Updated Jetbricks to support containers running with Java 9+

### DIFF
--- a/ext/jetbrick/pom.xml
+++ b/ext/jetbrick/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright © 2017, 2019 Ivar Grimstad
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -29,20 +29,15 @@
   <packaging>jar</packaging>
   <name>Eclipse Krazo Jetbrick Extension</name>
 	<dependencies>
-		<dependency>
-			<groupId>com.github.subchen</groupId>
-			<artifactId>jetbrick-template</artifactId>
-			<version>2.1.6</version>
-		</dependency>
+        <dependency>
+            <groupId>com.github.subchen</groupId>
+            <artifactId>jetbrick-template</artifactId>
+            <version>2.1.10</version>
+        </dependency>
 		<dependency>
 			<groupId>com.github.subchen</groupId>
 			<artifactId>jetbrick-template-web</artifactId>
-			<version>2.1.6</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7.1</version>
+			<version>2.1.10</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Apps using the jetbricks extension fail to deploy if the container runs on Java 9 (or newer). This affects the Wildfly- (#70) as well as the new TomEE-Testsuite (#76).

The issue has been fixed upstream, so all we need to do is update.