### PR TITLE
Removed tck-glassfish51-vanilla profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ jobs:
       before_script: .travis/docker-tomee.sh
       script: mvn -P${TYPE} --projects testsuite clean verify
     - stage: test
-      env: TYPE=tck-glassfish51-vanilla
-      script: .travis/tests.sh ${TYPE}
-    - stage: test
       env: TYPE=tck-glassfish51-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test
@@ -43,7 +40,6 @@ jobs:
       env: TYPE=tck-liberty
       script: .travis/tests.sh ${TYPE}
   allow_failures:
-    - env: TYPE=tck-glassfish51-vanilla
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty
     - env: TYPE=testsuite-wildfly


### PR DESCRIPTION
Glassfish 5.1 is known to not work correctly with Krazo because of known issues in Jersey 2.28 which have been fixed in 2.29. So I don't think it makes sense to keep the `tck-glassfish51-vanilla` anymore. Hopefully there will be a new Glassfish release soon with an updated Jersey version.