### PR TITLE
cache maven dependencies in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ jdk: oraclejdk8
 services:
 - docker
 
+cache:
+  directories:
+  - $HOME/.m2
+
 jobs:
   include:
     - stage: build


### PR DESCRIPTION
Travis builds have become a little slow. This caches dependencies so we don't have to download them every time