### PR TITLE
Disable processing of view-annotations if controller does not complete

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
@@ -102,7 +102,7 @@ public class KrazoCdiExtension implements Extension {
                 ModelsImpl.class,
                 ViewableWriter.class,
                 ViewResponseFilter.class,
-                
+
                 // lifecycle
                 EventDispatcher.class,
                 RequestLifecycle.class,
@@ -213,5 +213,14 @@ public class KrazoCdiExtension implements Extension {
      */
     public static synchronized boolean isEventObserved(Class<? extends MvcEvent> eventType) {
         return observedEvents == null ? false : observedEvents.contains(eventType);
+    }
+
+    /**
+     * Clears all observed events
+     * <p>
+     * This is used for testing
+     */
+    public static synchronized void clearEventsObserved() {
+        observedEvents = null;
     }
 }

--- a/core/src/main/java/org/eclipse/krazo/core/RequestAttributes.java
+++ b/core/src/main/java/org/eclipse/krazo/core/RequestAttributes.java
@@ -1,0 +1,9 @@
+package org.eclipse.krazo.core;
+
+/**
+ * @author Gregor Tudan
+ */
+public enum RequestAttributes {
+
+    CONTROLLER_EXECUTED
+}

--- a/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
@@ -20,6 +20,7 @@ package org.eclipse.krazo.engine;
 import javax.mvc.Controller;
 import javax.mvc.Models;
 import javax.mvc.engine.ViewEngine;
+import java.util.Objects;
 
 /**
  * <p>An abstraction that encapsulates information about a view as well as an instance
@@ -140,5 +141,20 @@ public class Viewable {
     @Override
     public String toString() {
         return view;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Viewable viewable = (Viewable) o;
+        return Objects.equals(view, viewable.view) &&
+            Objects.equals(models, viewable.models) &&
+            Objects.equals(viewEngine, viewable.viewEngine);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(view, models, viewEngine);
     }
 }

--- a/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
+++ b/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
@@ -18,12 +18,12 @@
 package org.eclipse.krazo.lifecycle;
 
 import org.eclipse.krazo.MvcContextImpl;
+import org.eclipse.krazo.core.RequestAttributes;
 import org.eclipse.krazo.jaxrs.JaxRsContext;
 import org.eclipse.krazo.locale.LocaleResolverChain;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 import java.util.Locale;
@@ -61,7 +61,7 @@ public class RequestLifecycle {
         eventDispatcher.fireBeforeControllerEvent();
         try {
             final Object result = controllerMethod.call();
-            request.setAttribute("controllerCompleted", true);
+            request.setAttribute(RequestAttributes.CONTROLLER_EXECUTED.name(), true);
             return result;
 
         } finally {

--- a/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
+++ b/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
@@ -18,10 +18,13 @@
 package org.eclipse.krazo.lifecycle;
 
 import org.eclipse.krazo.MvcContextImpl;
+import org.eclipse.krazo.jaxrs.JaxRsContext;
 import org.eclipse.krazo.locale.LocaleResolverChain;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 import java.util.Locale;
 import java.util.concurrent.Callable;
@@ -41,6 +44,10 @@ public class RequestLifecycle {
     @Inject
     private MvcContextImpl mvc;
 
+    @Inject
+    @JaxRsContext
+    private HttpServletRequest request;
+
     public void beforeAll(ContainerRequestContext context) {
 
         // initialize request locale
@@ -53,8 +60,9 @@ public class RequestLifecycle {
 
         eventDispatcher.fireBeforeControllerEvent();
         try {
-
-            return controllerMethod.call();
+            final Object result = controllerMethod.call();
+            request.setAttribute("controllerCompleted", true);
+            return result;
 
         } finally {
             eventDispatcher.fireAfterControllerEvent();

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -17,55 +17,261 @@
  */
 package org.eclipse.krazo.core;
 
-import org.junit.Test;
+import com.sun.xml.internal.ws.client.ResponseContext;
+import org.easymock.*;
+import org.eclipse.krazo.KrazoConfig;
+import org.eclipse.krazo.cdi.KrazoCdiExtension;
+import org.eclipse.krazo.engine.Viewable;
+import org.eclipse.krazo.event.ControllerRedirectEventImpl;
+import org.eclipse.krazo.lifecycle.EventDispatcher;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import sun.security.provider.certpath.OCSPResponse;
 
+import javax.enterprise.event.Event;
+import javax.mvc.View;
+import javax.mvc.event.ControllerRedirectEvent;
+import javax.mvc.event.MvcEvent;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
 
 /**
  * Test for ViewResponseFilter
  *
  * @author Dmytro Maidaniuk
  */
-@RunWith(value = Parameterized.class)
+@RunWith(org.junit.experimental.runners.Enclosed.class)
 public class ViewResponseFilterTest {
 
-    private String viewName;
+    public static class ResponseFilterTest extends EasyMockSupport {
 
-    private String defaultExtension;
+        @Rule
+        public EasyMockRule easyMockRule = new EasyMockRule(this);
 
-    private String expectedViewName;
+        @Mock(type = MockType.NICE)
+        private ContainerRequestContext requestContext;
 
-    public ViewResponseFilterTest(String viewName,
-                                  String defaultExtension,
-                                  String expectedViewName) {
-        this.viewName = viewName;
-        this.defaultExtension = defaultExtension;
-        this.expectedViewName = expectedViewName;
+        @Mock(type = MockType.NICE)
+        private ContainerResponseContext responseContext;
+
+        @Mock(type = MockType.NICE)
+        private HttpServletRequest request;
+
+        @Mock(type = MockType.NICE)
+        private ResourceInfo resourceInfo;
+
+        @Mock(type = MockType.NICE)
+        private UriInfo uriInfo;
+
+        @Mock(type = MockType.NICE)
+        private Event<MvcEvent> dispatcher;
+
+        @Mock(type = MockType.NICE)
+        private KrazoConfig krazoConfig = new KrazoConfig();
+
+        @TestSubject
+        private ViewResponseFilter responseFilter = new ViewResponseFilter();
+
+        private Object responseEntity;
+        private MultivaluedHashMap<String, Object> responseHeaders;
+        private Response.Status responseStatus;
+
+        void mockControllerCall(Object controller, String methodName) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            final Method method = controller.getClass().getMethod(methodName);
+            responseEntity = method.invoke(controller);
+            responseStatus = method.getReturnType() == Void.TYPE ? Response.Status.NO_CONTENT : Response.Status.OK;
+
+            expect(resourceInfo.getResourceMethod()).andStubReturn(method);
+            expect((Object) resourceInfo.getResourceClass()).andStubReturn(controller.getClass());
+            expect(responseContext.getEntity()).andAnswer(() -> responseEntity);
+            expect(responseContext.getEntity()).andAnswer(() -> responseEntity);
+        }
+
+        @AfterClass
+        public static void clearRegisteredEvents() {
+            KrazoCdiExtension.clearEventsObserved();
+        }
+
+        @Before
+        public void setUp() throws Exception {
+            expect(request.getAttribute(anyString())).andReturn(null);
+            expect(krazoConfig.getDefaultViewFileExtension()).andReturn("jsp");
+            expect(uriInfo.getBaseUri()).andStubReturn(new URI("/"));
+
+            responseHeaders = new MultivaluedHashMap<>();
+            expect(responseContext.getHeaders()).andStubReturn(responseHeaders);
+            expect(responseContext.getHeaderString(anyString())).andStubAnswer(() -> String.valueOf(responseHeaders.getFirst((String) EasyMock.getCurrentArguments()[0])));
+
+            Capture<Object> responseEntityCapture = newCapture();
+            responseContext.setEntity(capture(responseEntityCapture), anyObject(), anyObject());
+            expectLastCall().andStubAnswer(() -> responseEntity = responseEntityCapture.getValue());
+
+            Capture<Response.Status> responseStatusCapture = newCapture();
+            responseContext.setStatusInfo(capture(responseStatusCapture));
+            expectLastCall().andStubAnswer(() -> responseStatus = responseStatusCapture.getValue());
+            expect(responseContext.getStatusInfo()).andStubAnswer(() -> responseStatus);
+            expect(responseContext.getStatus()).andStubAnswer(() -> responseStatus.getStatusCode());
+        }
+
+        @Test
+        public void testFilteringStringEntities() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            mockControllerCall(new SampleController(), "view");
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            assertEquals(responseEntity, new Viewable("helloWorld.jsp"));
+        }
+
+        @Test
+        public void testFilteringVoidMethodsWithViewAnnotation() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            mockControllerCall(new SampleController(), "annotatedView");
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            assertEquals(new Viewable("helloAnnotation.jsp"), responseEntity);
+            assertEquals(Response.Status.OK, responseStatus);
+        }
+
+        @Test
+        public void testFilteringVoidMethodsWithAnnotatedController() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            mockControllerCall(new AnnotatedController(), "view");
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            assertEquals(new Viewable("helloWorld.jsp"), responseEntity);
+            assertEquals(Response.Status.OK, responseStatus);
+        }
+
+        @Test
+        public void testFilteringRedirect() throws IOException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            mockControllerCall(new SampleController(), "redirect");
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            assertEquals(new Viewable("redirect:view"), responseEntity);
+            assertEquals(Response.Status.SEE_OTHER, responseStatus);
+            assertEquals("/view", responseHeaders.getFirst(HttpHeaders.LOCATION));
+        }
+
+        @Test
+        public void testFiringRedirectEvents() throws Exception {
+            KrazoCdiExtension.addObservedEvent(ControllerRedirectEvent.class);
+
+            mockControllerCall(new SampleController(), "redirect");
+            final Capture<MvcEvent> mvcEvent = newCapture();
+            dispatcher.fire(capture(mvcEvent));
+            expectLastCall().once();
+
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            final ControllerRedirectEvent redirectEvent = (ControllerRedirectEvent) mvcEvent.getValue();
+            assertEquals(redirectEvent.getLocation(), new URI("/view"));
+        }
+
+        @Test
+        public void testSimulatedException() throws Exception {
+            final Method method = SampleController.class.getMethod("annotatedView");
+            expect(resourceInfo.getResourceMethod()).andStubReturn(method);
+            expect((Object) resourceInfo.getResourceClass()).andStubReturn(SampleController.class);
+            responseStatus = Response.Status.FORBIDDEN;
+
+            replayAll();
+
+            responseFilter.filter(requestContext, responseContext);
+
+            verifyAll();
+            assertEquals(responseStatus, Response.Status.FORBIDDEN);
+            assertNull(responseEntity);
+        }
+
+        private static class SampleController {
+
+            public String view() {
+                return "helloWorld";
+            }
+
+            @View("helloAnnotation")
+            public void annotatedView() {
+
+            }
+
+            public String redirect() {
+                return "redirect:view";
+            }
+        }
+
+        @View("helloWorld.jsp")
+        private static class AnnotatedController {
+
+            public void view() {
+
+            }
+        }
     }
 
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {"main.jsp", "jsp", "main.jsp"},
-            {"main", "jsp", "main.jsp"},
-            {"main", null, "main"},
-            {"main", "", "main"},
-            {"redirect:some.jsp", "jsp", "redirect:some.jsp"},
-            {"react:some", "jsp", "react:some.jsp"},
-            {"main.", "jsp", "main."}
-        });
-    }
+    @RunWith(value = Parameterized.class)
+    public static class AppendExtensionTest {
 
-    @Test
-    public void testAppendExtensionIfRequired() {
-        String actualViewName = ViewResponseFilter.appendExtensionIfRequired(viewName, defaultExtension);
-        assertEquals(expectedViewName, actualViewName);
+        private String viewName;
+        private String defaultExtension;
+        private String expectedViewName;
+
+        public AppendExtensionTest(String viewName,
+                                   String defaultExtension,
+                                   String expectedViewName) {
+            this.viewName = viewName;
+            this.defaultExtension = defaultExtension;
+            this.expectedViewName = expectedViewName;
+        }
+
+        @Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                {"main.jsp", "jsp", "main.jsp"},
+                {"main", "jsp", "main.jsp"},
+                {"main", null, "main"},
+                {"main", "", "main"},
+                {"redirect:some.jsp", "jsp", "redirect:some.jsp"},
+                {"react:some", "jsp", "react:some.jsp"},
+                {"main.", "jsp", "main."}
+            });
+        }
+
+        @Test
+        public void testAppendExtensionIfRequired() {
+            String actualViewName = ViewResponseFilter.appendExtensionIfRequired(viewName, defaultExtension);
+            assertEquals(expectedViewName, actualViewName);
+        }
     }
 
 }


### PR DESCRIPTION
The processing of the view annotations is disables by setting an attribute in the aroundControllerInterceptor if and only if the controller ran and completed without an exception.

Fixes #91 where views configured by a view annotation would still be rendered if an exception handler kicked in.

Sorry about the amount of change in the ViewResponseFilter - I had to catch some edge cases and get the class under test.

The test requires a lot of dirty mocking, but I did not want to refactor even more stuff to keep the PR readable.