### PR TITLE
Fixed copyright line in file headers

### DIFF
--- a/core/findbugs-exclude.xml
+++ b/core/findbugs-exclude.xml
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
+++ b/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/MvcContextImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/MvcContextImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/Properties.java
+++ b/core/src/main/java/org/eclipse/krazo/Properties.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/BeanValidationProducer.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/BeanValidationProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/BindingErrorImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/BindingErrorImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/BindingResultImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/BindingResultImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/BindingResultManager.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/BindingResultManager.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/ConstraintViolationTranslator.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/ConstraintViolationTranslator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/ValidationErrorImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/ValidationErrorImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterResult.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/ConverterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverterProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/MvcConverterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BooleanConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BooleanConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/DoubleConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/DoubleConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/FloatConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/FloatConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/IntegerConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/IntegerConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/LongConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/NumberConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/NumberConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/ShortConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/ShortConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/validate/ConstraintViolationMetadata.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/validate/ConstraintViolationMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/validate/ConstraintViolations.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/validate/ConstraintViolations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptor.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptorBinding.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/validate/ValidationInterceptorBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/bootstrap/ConfigProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/ConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/bootstrap/CoreFeature.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/CoreFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/bootstrap/DefaultConfigProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/DefaultConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/bootstrap/Initializer.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/Initializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/AroundController.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/AroundController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/AroundControllerInterceptor.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/AroundControllerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/Internal.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/Internal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/RedirectScopeContext.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/RedirectScopeContext.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/RedirectScopeManager.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/RedirectScopeManager.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedMethodWrapper.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedMethodWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeProcessor.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeWrapper.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/core/Messages.java
+++ b/core/src/main/java/org/eclipse/krazo/core/Messages.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/core/ModelsImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ModelsImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/core/ViewResponseFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewResponseFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/FaceletsViewEngine.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/FaceletsViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/JspViewEngine.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/JspViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/ServletViewEngine.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/ServletViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/ViewEngineBase.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/ViewEngineBase.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/ViewEngineConfig.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/ViewEngineConfig.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/ViewEngineContextImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/ViewEngineContextImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/ViewEngineFinder.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/ViewEngineFinder.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
+++ b/core/src/main/java/org/eclipse/krazo/engine/Viewable.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017-2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/event/AfterControllerEventImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/event/AfterControllerEventImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/event/AfterProcessViewEventImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/event/AfterProcessViewEventImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/event/BeforeControllerEventImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/event/BeforeControllerEventImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/event/BeforeProcessViewEventImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/event/BeforeProcessViewEventImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/event/ControllerRedirectEventImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/event/ControllerRedirectEventImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/forms/HiddenMethodFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/forms/HiddenMethodFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContext.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/lifecycle/EventDispatcher.java
+++ b/core/src/main/java/org/eclipse/krazo/lifecycle/EventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
+++ b/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/locale/DefaultLocaleResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/locale/DefaultLocaleResolver.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/locale/LocaleResolverChain.java
+++ b/core/src/main/java/org/eclipse/krazo/locale/LocaleResolverChain.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/locale/LocaleResolverContextImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/locale/LocaleResolverContextImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CookieCsrfTokenStrategy.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CookieCsrfTokenStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfExceptionMapper.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfProtectFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfProtectFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfToken.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfTokenManager.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfTokenManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfTokenStrategy.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfTokenStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfValidateFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfValidateFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/DefaultFormEntityProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/security/DefaultFormEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/EncodersImpl.java
+++ b/core/src/main/java/org/eclipse/krazo/security/EncodersImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/FormEntityProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/security/FormEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/security/SessionCsrfTokenStrategy.java
+++ b/core/src/main/java/org/eclipse/krazo/security/SessionCsrfTokenStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/servlet/KrazoContainerInitializer.java
+++ b/core/src/main/java/org/eclipse/krazo/servlet/KrazoContainerInitializer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/servlet/KrazoServletContextListener.java
+++ b/core/src/main/java/org/eclipse/krazo/servlet/KrazoServletContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/uri/ApplicationUris.java
+++ b/core/src/main/java/org/eclipse/krazo/uri/ApplicationUris.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/uri/UriTemplate.java
+++ b/core/src/main/java/org/eclipse/krazo/uri/UriTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/uri/UriTemplateParser.java
+++ b/core/src/main/java/org/eclipse/krazo/uri/UriTemplateParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/BeanUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/BeanUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/CdiUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/CdiUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/ControllerUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/ControllerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/PathUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/PathUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/PropertyUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/PropertyUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/eclipse/krazo/util/ServiceLoaders.java
+++ b/core/src/main/java/org/eclipse/krazo/util/ServiceLoaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/resources/META-INF/web-fragment.xml
+++ b/core/src/main/resources/META-INF/web-fragment.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/ConverterRegistryTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/ConverterRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigIntegerConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BooleanConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ConversionTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/DoubleConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/DoubleConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/FloatConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/FloatConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/IntegerConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/IntegerConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/LongConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/LongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ShortConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/ShortConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/validate/BaseUser.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/validate/BaseUser.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/validate/ConstraintViolationsMvcBindingTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/validate/ConstraintViolationsMvcBindingTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/validate/ConstraintViolationsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/validate/ConstraintViolationsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/validate/MvcUser.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/validate/MvcUser.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/binding/validate/NotAJavaBean.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/validate/NotAJavaBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/cdi/RedirectScopeManagerInjectionVerifyTest.java
+++ b/core/src/test/java/org/eclipse/krazo/cdi/RedirectScopeManagerInjectionVerifyTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/core/MessagesTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/MessagesTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/core/ModelsImplTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ModelsImplTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/core/ViewableWriterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewableWriterTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/engine/ViewEngineBaseTest.java
+++ b/core/src/test/java/org/eclipse/krazo/engine/ViewEngineBaseTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/engine/ViewEngineContextImplTest.java
+++ b/core/src/test/java/org/eclipse/krazo/engine/ViewEngineContextImplTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/security/CsrfValidateFilterMediaTypeTest.java
+++ b/core/src/test/java/org/eclipse/krazo/security/CsrfValidateFilterMediaTypeTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/security/DefaultFormEntityProviderTest.java
+++ b/core/src/test/java/org/eclipse/krazo/security/DefaultFormEntityProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/security/EncodersImplTest.java
+++ b/core/src/test/java/org/eclipse/krazo/security/EncodersImplTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/servlet/KrazoServletContextListenerTest.java
+++ b/core/src/test/java/org/eclipse/krazo/servlet/KrazoServletContextListenerTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/uri/ApplicationUrisTest.java
+++ b/core/src/test/java/org/eclipse/krazo/uri/ApplicationUrisTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/uri/UriBuilderTestControllers.java
+++ b/core/src/test/java/org/eclipse/krazo/uri/UriBuilderTestControllers.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/uri/UriTemplateParserTest.java
+++ b/core/src/test/java/org/eclipse/krazo/uri/UriTemplateParserTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/BeanUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/BeanUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/CdiUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/CdiUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/ControllerUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/ControllerUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/PathUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/PathUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/eclipse/krazo/util/PropertyUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/PropertyUtilsTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/resources/META-INF/beans.xml
+++ b/core/src/test/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/cxf/pom.xml
+++ b/cxf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/annotations/pom.xml
+++ b/examples/annotations/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/AnnotationsController.java
+++ b/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/AnnotationsController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/BaseController.java
+++ b/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/BaseController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/BaseInterface.java
+++ b/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/BaseInterface.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/MyApplication.java
+++ b/examples/annotations/src/main/java/org/eclipse/krazo/test/annotations/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/annotations/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/annotations/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/annotations/src/test/java/org/eclipse/krazo/test/annotations/AnnotationsIT.java
+++ b/examples/annotations/src/test/java/org/eclipse/krazo/test/annotations/AnnotationsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/application-path/pom.xml
+++ b/examples/application-path/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/Book.java
+++ b/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/Book.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/BookController.java
+++ b/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/BookController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/Catalog.java
+++ b/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/Catalog.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/MyApplication.java
+++ b/examples/application-path/src/main/java/org/eclipse/krazo/test/applicationpath/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/application-path/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/application-path/src/main/webapp/WEB-INF/web.xml
+++ b/examples/application-path/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/application-path/src/test/java/org/eclipse/krazo/test/applicationpath/ApplicationPathIT.java
+++ b/examples/application-path/src/test/java/org/eclipse/krazo/test/applicationpath/ApplicationPathIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-cdi/pom.xml
+++ b/examples/book-cdi/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/Book.java
+++ b/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/Book.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/BookController.java
+++ b/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/BookController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/MyApplication.java
+++ b/examples/book-cdi/src/main/java/org/eclipse/krazo/test/bookcdi/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/book-cdi/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/main/webapp/WEB-INF/web.xml
+++ b/examples/book-cdi/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/book-cdi/src/test/java/org/eclipse/krazo/test/bookcdi/BookCdiIT.java
+++ b/examples/book-cdi/src/test/java/org/eclipse/krazo/test/bookcdi/BookCdiIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-models/pom.xml
+++ b/examples/book-models/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/Book.java
+++ b/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/Book.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/BookController.java
+++ b/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/BookController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/MyApplication.java
+++ b/examples/book-models/src/main/java/org/eclipse/krazo/test/bookmodels/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/book-models/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/book-models/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/book-models/src/test/java/org/eclipse/krazo/test/bookmodels/BookModelsIT.java
+++ b/examples/book-models/src/test/java/org/eclipse/krazo/test/bookmodels/BookModelsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/conversation/pom.xml
+++ b/examples/conversation/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/ConversationController.java
+++ b/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/ConversationController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/MyApplication.java
+++ b/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/SecretBean.java
+++ b/examples/conversation/src/main/java/org/eclipse/krazo/test/conversation/SecretBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/conversation/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/conversation/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/conversation/src/test/java/org/eclipse/krazo/test/conversation/ConversationIT.java
+++ b/examples/conversation/src/test/java/org/eclipse/krazo/test/conversation/ConversationIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/csrf-property/pom.xml
+++ b/examples/csrf-property/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/CsrfController.java
+++ b/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/CsrfController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/ForbiddenExceptionMapper.java
+++ b/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/ForbiddenExceptionMapper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/MyApplication.java
+++ b/examples/csrf-property/src/main/java/org/eclipse/krazo/test/csrfproperty/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/csrf-property/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/csrf-property/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/csrf-property/src/test/java/org/eclipse/krazo/test/csrfproperty/CsrfIT.java
+++ b/examples/csrf-property/src/test/java/org/eclipse/krazo/test/csrfproperty/CsrfIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/def-ext/pom.xml
+++ b/examples/def-ext/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/def-ext/src/main/java/org/eclipse/krazo/test/mvc/DefaultExtensionController.java
+++ b/examples/def-ext/src/main/java/org/eclipse/krazo/test/mvc/DefaultExtensionController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/def-ext/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
+++ b/examples/def-ext/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/def-ext/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/def-ext/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/def-ext/src/test/java/org/eclipse/krazo/test/mvc/DefaultExtensionIT.java
+++ b/examples/def-ext/src/test/java/org/eclipse/krazo/test/mvc/DefaultExtensionIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/events/src/main/java/org/eclipse/krazo/test/events/EventBean.java
+++ b/examples/events/src/main/java/org/eclipse/krazo/test/events/EventBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/events/src/main/java/org/eclipse/krazo/test/events/EventController.java
+++ b/examples/events/src/main/java/org/eclipse/krazo/test/events/EventController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/events/src/main/java/org/eclipse/krazo/test/events/EventObserver.java
+++ b/examples/events/src/main/java/org/eclipse/krazo/test/events/EventObserver.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/events/src/main/java/org/eclipse/krazo/test/events/MyApplication.java
+++ b/examples/events/src/main/java/org/eclipse/krazo/test/events/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/events/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/events/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/events/src/test/java/org/eclipse/krazo/test/events/EventsIT.java
+++ b/examples/events/src/test/java/org/eclipse/krazo/test/events/EventsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/exceptions/pom.xml
+++ b/examples/exceptions/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/HelloController.java
+++ b/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/MyApplication.java
+++ b/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/exceptions/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/exceptions/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/exceptions/src/test/java/org/eclipse/krazo/test/exceptions/ExceptionsIT.java
+++ b/examples/exceptions/src/test/java/org/eclipse/krazo/test/exceptions/ExceptionsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/facelets/pom.xml
+++ b/examples/facelets/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/Book.java
+++ b/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/Book.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/BookController.java
+++ b/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/BookController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/Catalog.java
+++ b/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/Catalog.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/MyApplication.java
+++ b/examples/facelets/src/main/java/org/eclipse/krazo/test/facelets/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/facelets/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/facelets/src/main/webapp/WEB-INF/web.xml
+++ b/examples/facelets/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/facelets/src/test/java/org/eclipse/krazo/test/facelets/FaceletsIT.java
+++ b/examples/facelets/src/test/java/org/eclipse/krazo/test/facelets/FaceletsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/locale/pom.xml
+++ b/examples/locale/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/locale/src/main/java/org/eclipse/krazo/test/locale/LocaleController.java
+++ b/examples/locale/src/main/java/org/eclipse/krazo/test/locale/LocaleController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/locale/src/main/java/org/eclipse/krazo/test/locale/MyApplication.java
+++ b/examples/locale/src/main/java/org/eclipse/krazo/test/locale/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/locale/src/main/java/org/eclipse/krazo/test/locale/QueryLocaleResolver.java
+++ b/examples/locale/src/main/java/org/eclipse/krazo/test/locale/QueryLocaleResolver.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/locale/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/locale/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/locale/src/test/java/org/eclipse/krazo/test/locale/LocaleIT.java
+++ b/examples/locale/src/test/java/org/eclipse/krazo/test/locale/LocaleIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/produces/pom.xml
+++ b/examples/produces/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/produces/src/main/java/org/eclipse/krazo/test/produces/HelloController.java
+++ b/examples/produces/src/main/java/org/eclipse/krazo/test/produces/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/produces/src/main/java/org/eclipse/krazo/test/produces/MyApplication.java
+++ b/examples/produces/src/main/java/org/eclipse/krazo/test/produces/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/produces/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/produces/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/produces/src/test/java/org/eclipse/krazo/test/produces/ProducesIT.java
+++ b/examples/produces/src/test/java/org/eclipse/krazo/test/produces/ProducesIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirect/pom.xml
+++ b/examples/redirect/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirect/src/main/java/org/eclipse/krazo/test/redirect/MyApplication.java
+++ b/examples/redirect/src/main/java/org/eclipse/krazo/test/redirect/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirect/src/main/java/org/eclipse/krazo/test/redirect/RedirectController.java
+++ b/examples/redirect/src/main/java/org/eclipse/krazo/test/redirect/RedirectController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirect/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/redirect/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirect/src/test/java/org/eclipse/krazo/test/redirect/RedirectIT.java
+++ b/examples/redirect/src/test/java/org/eclipse/krazo/test/redirect/RedirectIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope/pom.xml
+++ b/examples/redirectScope/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/MyApplication.java
+++ b/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/RedirectBean.java
+++ b/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/RedirectBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/RedirectController.java
+++ b/examples/redirectScope/src/main/java/org/eclipse/krazo/test/redirectscope/RedirectController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/redirectScope/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirectScope/src/test/java/org/eclipse/krazo/test/redirectscope/RedirectScopeIT.java
+++ b/examples/redirectScope/src/test/java/org/eclipse/krazo/test/redirectscope/RedirectScopeIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/pom.xml
+++ b/examples/redirectScope2/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/MyApplication.java
+++ b/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/RedirectBean.java
+++ b/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/RedirectBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/RedirectController.java
+++ b/examples/redirectScope2/src/main/java/org/eclipse/krazo/test/redirectscope2/RedirectController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/redirectScope2/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/redirectScope2/src/test/java/org/eclipse/krazo/test/redirectscope2/RedirectScopeIT.java
+++ b/examples/redirectScope2/src/test/java/org/eclipse/krazo/test/redirectscope2/RedirectScopeIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/pom.xml
+++ b/examples/requestDispatcher/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/src/main/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherApplication.java
+++ b/examples/requestDispatcher/src/main/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/src/main/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherController.java
+++ b/examples/requestDispatcher/src/main/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/requestDispatcher/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/src/main/webapp/WEB-INF/web.xml
+++ b/examples/requestDispatcher/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/requestDispatcher/src/test/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherIT.java
+++ b/examples/requestDispatcher/src/test/java/org/eclipse/krazo/test/requestdispatcher/RequestDispatcherIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/returns/pom.xml
+++ b/examples/returns/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/returns/src/main/java/org/eclipse/krazo/test/returns/HelloController.java
+++ b/examples/returns/src/main/java/org/eclipse/krazo/test/returns/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/returns/src/main/java/org/eclipse/krazo/test/returns/MyApplication.java
+++ b/examples/returns/src/main/java/org/eclipse/krazo/test/returns/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/returns/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/returns/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/returns/src/test/java/org/eclipse/krazo/test/returns/ReturnsIT.java
+++ b/examples/returns/src/test/java/org/eclipse/krazo/test/returns/ReturnsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/uri-builder/pom.xml
+++ b/examples/uri-builder/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/ParameterController.java
+++ b/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/ParameterController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/UriBuilderApplication.java
+++ b/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/UriBuilderApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/UriBuilderController.java
+++ b/examples/uri-builder/src/main/java/org/eclipse/krazo/test/uribuilder/UriBuilderController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/uri-builder/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/uri-builder/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/uri-builder/src/test/java/org/eclipse/krazo/test/uribuilder/UriBuilderIT.java
+++ b/examples/uri-builder/src/test/java/org/eclipse/krazo/test/uribuilder/UriBuilderIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/pom.xml
+++ b/examples/validation-i18n/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/FormBean.java
+++ b/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/FormBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/MyApplication.java
+++ b/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/QueryLocaleResolver.java
+++ b/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/QueryLocaleResolver.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/ValidationController.java
+++ b/examples/validation-i18n/src/main/java/org/eclipse/krazo/test/validation/ValidationController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/validation-i18n/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/validation-i18n/src/test/java/org/eclipse/krazo/test/validation/I18NValidationIT.java
+++ b/examples/validation-i18n/src/test/java/org/eclipse/krazo/test/validation/I18NValidationIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/pom.xml
+++ b/examples/validation/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/ErrorDataBean.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/ErrorDataBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormController.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormControllerBase.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormControllerBase.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormControllerProperty.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormControllerProperty.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormDataBean.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/FormDataBean.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/java/org/eclipse/krazo/test/validation/MyApplication.java
+++ b/examples/validation/src/main/java/org/eclipse/krazo/test/validation/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/validation/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/validation/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/validation/src/test/java/org/eclipse/krazo/test/validation/ValidationIT.java
+++ b/examples/validation/src/test/java/org/eclipse/krazo/test/validation/ValidationIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/view-annotation/pom.xml
+++ b/examples/view-annotation/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/HelloController.java
+++ b/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/MyApplication.java
+++ b/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/view-annotation/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/view-annotation/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/view-annotation/src/main/webapp/WEB-INF/web.xml
+++ b/examples/view-annotation/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/examples/view-annotation/src/test/java/org/eclipse/krazo/test/view/ViewAnnotationIT.java
+++ b/examples/view-annotation/src/test/java/org/eclipse/krazo/test/view/ViewAnnotationIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/asciidoc/pom.xml
+++ b/ext/asciidoc/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/asciidoc/src/main/java/org/eclipse/krazo/ext/asciidoc/AsciiDocViewEngine.java
+++ b/ext/asciidoc/src/main/java/org/eclipse/krazo/ext/asciidoc/AsciiDocViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/asciidoc/src/main/resources/META-INF/beans.xml
+++ b/ext/asciidoc/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/freemarker/pom.xml
+++ b/ext/freemarker/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/DefaultConfigurationProducer.java
+++ b/ext/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/DefaultConfigurationProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/FreemarkerViewEngine.java
+++ b/ext/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/FreemarkerViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/freemarker/src/main/resources/META-INF/beans.xml
+++ b/ext/freemarker/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/DefaultHandlebarsProducer.java
+++ b/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/DefaultHandlebarsProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/HandlebarsViewEngine.java
+++ b/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/HandlebarsViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/handlebars/src/main/resources/META-INF/beans.xml
+++ b/ext/handlebars/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jade/pom.xml
+++ b/ext/jade/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/JadeKrazoConfiguration.java
+++ b/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/JadeKrazoConfiguration.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/JadeViewEngine.java
+++ b/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/JadeViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/ServletContextTemplateLoader.java
+++ b/ext/jade/src/main/java/org/eclipse/krazo/ext/jade/ServletContextTemplateLoader.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jade/src/main/resources/META-INF/beans.xml
+++ b/ext/jade/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jetbrick/pom.xml
+++ b/ext/jetbrick/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2019 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jetbrick/src/main/java/org/eclipse/krazo/ext/jetbrick/JetbrickViewEngine.java
+++ b/ext/jetbrick/src/main/java/org/eclipse/krazo/ext/jetbrick/JetbrickViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jetbrick/src/main/resources/META-INF/beans.xml
+++ b/ext/jetbrick/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jsr223/pom.xml
+++ b/ext/jsr223/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jsr223/src/main/java/org/eclipse/krazo/ext/jsr223/Jsr223ViewEngine.java
+++ b/ext/jsr223/src/main/java/org/eclipse/krazo/ext/jsr223/Jsr223ViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jtwig/pom.xml
+++ b/ext/jtwig/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/jtwig/src/main/java/org/eclipse/krazo/ext/jtwig/JtwigViewEngine.java
+++ b/ext/jtwig/src/main/java/org/eclipse/krazo/ext/jtwig/JtwigViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/jtwig/src/main/resources/META-INF/beans.xml
+++ b/ext/jtwig/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/mustache/pom.xml
+++ b/ext/mustache/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/mustache/src/main/java/org/eclipse/krazo/ext/mustache/DefaultMustacheFactoryProducer.java
+++ b/ext/mustache/src/main/java/org/eclipse/krazo/ext/mustache/DefaultMustacheFactoryProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/mustache/src/main/java/org/eclipse/krazo/ext/mustache/MustacheViewEngine.java
+++ b/ext/mustache/src/main/java/org/eclipse/krazo/ext/mustache/MustacheViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/mustache/src/main/resources/META-INF/beans.xml
+++ b/ext/mustache/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/pebble/pom.xml
+++ b/ext/pebble/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducer.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducer.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleProperty.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleProperty.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleViewEngine.java
+++ b/ext/pebble/src/main/java/org/eclipse/krazo/ext/pebble/PebbleViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/main/resources/META-INF/beans.xml
+++ b/ext/pebble/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomEscapingStrategy.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomEscapingStrategy.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExecutorService.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExecutorService.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionOne.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionOne.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionTwo.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/CustomExtensionTwo.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducerTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleConfigurationProducerTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducerTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleEngineProducerTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebblePropertyTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebblePropertyTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleViewEngineTest.java
+++ b/ext/pebble/src/test/java/org/eclipse/krazo/ext/pebble/PebbleViewEngineTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/stringtemplate/pom.xml
+++ b/ext/stringtemplate/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/stringtemplate/src/main/java/org/eclipse/krazo/ext/stringtemplate/StringTemplateViewEngine.java
+++ b/ext/stringtemplate/src/main/java/org/eclipse/krazo/ext/stringtemplate/StringTemplateViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/stringtemplate/src/main/resources/META-INF/beans.xml
+++ b/ext/stringtemplate/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/thymeleaf/pom.xml
+++ b/ext/thymeleaf/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/CDIWebContext.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/CDIWebContext.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultTemplateEngineProducer.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultTemplateEngineProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/ThymeleafViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/thymeleaf/src/main/resources/META-INF/beans.xml
+++ b/ext/thymeleaf/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/DefaultVelocityEngineProducer.java
+++ b/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/DefaultVelocityEngineProducer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/VelocityViewEngine.java
+++ b/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/VelocityViewEngine.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ext/velocity/src/main/resources/META-INF/beans.xml
+++ b/ext/velocity/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/jersey/src/main/java/org/eclipse/krazo/jersey/bootstrap/JerseyConfigProvider.java
+++ b/jersey/src/main/java/org/eclipse/krazo/jersey/bootstrap/JerseyConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/src/main/java/org/eclipse/krazo/jersey/bootstrap/KrazoJerseyFeature.java
+++ b/jersey/src/main/java/org/eclipse/krazo/jersey/bootstrap/KrazoJerseyFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/src/main/java/org/eclipse/krazo/jersey/model/KrazoModelProcessor.java
+++ b/jersey/src/main/java/org/eclipse/krazo/jersey/model/KrazoModelProcessor.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/src/main/java/org/eclipse/krazo/jersey/validation/KrazoValidationInterceptor.java
+++ b/jersey/src/main/java/org/eclipse/krazo/jersey/validation/KrazoValidationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jersey/src/test/java/org/eclipse/krazo/jersey/model/KrazoModelProcessorTest.java
+++ b/jersey/src/test/java/org/eclipse/krazo/jersey/model/KrazoModelProcessorTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright © 2017, 2019 Ivar Grimstad
+    Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2019 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/bootstrap/RestEasyConfigProvider.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/bootstrap/RestEasyConfigProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/security/RestEasyFormEntityProvider.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/security/RestEasyFormEntityProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoValidationResolver.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoValidationResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/AbstractArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/AbstractArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishDevArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishDevArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/liberty/LibertyArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/liberty/LibertyArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/liberty/LibertyDevArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/liberty/LibertyDevArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/tomee/TomeeArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/tomee/TomeeArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/tomee/TomeeDevArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/tomee/TomeeDevArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/wildfly/WildflyArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/wildfly/WildflyArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/main/java/org/eclipse/krazo/tck/wildfly/WildflyDevArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/wildfly/WildflyDevArchiveProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tck/src/test/resources/arquillian.xml
+++ b/tck/src/test/resources/arquillian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/CsrfController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/CsrfController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/Person.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/Person.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/PersonController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/PersonController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/DummyFilter.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/DummyFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/MathHelper.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/MathHelper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/Jsr223Application.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/Jsr223Application.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/JythonController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/JythonController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/NashornController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/NashornController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/pebble/PebbleApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/pebble/PebbleApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/pebble/PebbleController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/pebble/PebbleController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/Greeting.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/Greeting.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/HelloController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/HelloController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MvcController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MvcController.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/main/resources/jade/views/includes/footer.jade
+++ b/testsuite/src/main/resources/jade/views/includes/footer.jade
@@ -1,2 +1,2 @@
 #footer
-  p.footer Copyright (c) Ivar Grimstad
+  p.footer Copyright (c) Eclipse Krazo committers and contributors

--- a/testsuite/src/test/java/org/eclipse/krazo/test/CsrfIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/CsrfIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/HiddenFormMethodIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/HiddenFormMethodIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/MvcIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/MvcIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/annotation/IgnoreOnWildfly.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/annotation/IgnoreOnWildfly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/AsciiDocIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/AsciiDocIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/FreemarkerIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/FreemarkerIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/HandlebarsIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/HandlebarsIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/JadeIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/JadeIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +83,7 @@ public class JadeIT {
     public void testIncludesViews() {
         webDriver.navigate().to(baseURL + "jade");
         WebElement footer = webDriver.findElement(By.xpath("//p[@class='footer']"));
-        assertTrue(footer.getText().contains("Ivar Grimstad"));
+        assertTrue(footer.getText().contains("Eclipse Krazo committers and contributors"));
     }
 
     @Test

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/JetbrickIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/JetbrickIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/JtwigIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/JtwigIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/MustacheIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/MustacheIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/PebbleIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/PebbleIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/StringTemplateIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/StringTemplateIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2018 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/VelocityIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/VelocityIT.java
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/java/org/eclipse/krazo/test/util/WebArchiveBuilder.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/util/WebArchiveBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, 2019 Ivar Grimstad
+ * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2017, 2018 Ivar Grimstad
+    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request fixes the copyright headers in the whole Krazo codebase. Basically it restores the original Oracle copyright lines in the code that was transferred back then and it unifies the headers to correctly indicate the copyright for all content added later.

I know that this is a very huge pull request. However, feel free to comment if you have any doubts. 