### PR TITLE
Use openjdk8 instead of oraclejdk8 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: required
-jdk: oraclejdk8
+jdk: openjdk8
 
 services:
 - docker


### PR DESCRIPTION
Looks like the build currently breaks because Travis doesn't support OracleJDK8 anymore.

Let's get this one in quickly.