### PR TITLE
Switch from Oracle JDK to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 sudo: required
-jdk: oraclejdk8
+jdk: openjdk8
 
 services:
 - docker


### PR DESCRIPTION
As discussed in #97, this switches the build from Oracle JDK to OpenJDK. The Java version stays the same, though.