### PR TITLE
Allow building with Java 9 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ jobs:
   include:
     - stage: build
       script: mvn -B -V -DskipTests -DperformRelease -Dgpg.skip clean install
+    - stage: build
+      script: mvn -B -V -DskipTests clean install
+      jdk: openjdk11
     - stage: test
       env: TYPE=glassfish-module
       script: .travis/tests.sh ${TYPE}

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,15 @@
     </build>
 
     <profiles>
-
+        <profile>
+            <id>jdk9plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-Xlint:serial</arg>
+                            <!-- disables the warning about the missing -bootclasspath on java 11 -->
+                            <arg>-Xlint:-options</arg>
                             <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>


### PR DESCRIPTION
This detects Java 9 and above and sets the `maven.compiler.release` property.
This makes the Java compiler generate Java 8 byte code, so we keep backwards compatibility with older Java versions.

Closes #97 