### PR TITLE
Un-whitelist green testsuites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,4 @@ jobs:
   allow_failures:
     - env: TYPE=tck-tomee
     - env: TYPE=tck-liberty
-    - env: TYPE=testsuite-wildfly
-    - env: TYPE=testsuite-tomee
     - env: TYPE=glassfish-module


### PR DESCRIPTION
The testsuites for wildfly and tomee are finally green. We can remove the travis whitelist before they break again 😛 