### PR TITLE
run the unit tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
     - stage: build
       script: mvn -B -V -DskipTests -DperformRelease -Dgpg.skip clean install
     - stage: test
+      script: mvn -B -V test
+    - stage: test
       env: TYPE=glassfish-module
       script: .travis/tests.sh ${TYPE}
     - stage: test


### PR DESCRIPTION
I just noticed that we don't execute the unit tests during the travis build. All stages have `-DskipTests`.

Here's a failing test. The build is still green.
https://github.com/gtudan/krazo/commit/3ac2c34899efe47c1cdc63c6763a6435713b380b

Let's add a stage that runs them.