### PR TITLE
Run ViewResponseFilter only if controller was executed successfully

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeProcessor.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/types/AnnotatedTypeProcessor.java
@@ -19,11 +19,10 @@ package org.eclipse.krazo.cdi.types;
 
 import org.eclipse.krazo.binding.validate.ValidationInterceptorBinding;
 import org.eclipse.krazo.cdi.AroundController;
+import org.eclipse.krazo.util.ControllerUtils;
 
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.AnnotatedType;
-import javax.mvc.Controller;
-import javax.ws.rs.*;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -67,13 +66,6 @@ public class AnnotatedTypeProcessor {
     private <T> AnnotatedMethod<? super T> getReplacement(AnnotatedType<T> type,
                                                           AnnotatedMethod<? super T> method) {
 
-        boolean isResourceMethod = method.getAnnotation(GET.class) != null ||
-            method.getAnnotation(POST.class) != null || method.getAnnotation(PUT.class) != null ||
-            method.getAnnotation(HEAD.class) != null || method.getAnnotation(DELETE.class) != null;
-
-        boolean hasControllerAnnotation =
-            method.getAnnotation(Controller.class) != null || type.getAnnotation(Controller.class) != null;
-
         // added to methods to intercept calls with our interceptors
         Set<Annotation> markerAnnotations = new LinkedHashSet<>(Arrays.asList(
                 () -> ValidationInterceptorBinding.class,
@@ -83,7 +75,7 @@ public class AnnotatedTypeProcessor {
         // drop Hibernate Validator's marker annotations to skip the native validation
         Predicate<Class> annotationBlacklist = clazz -> isHibernateValidatorMarkerAnnotation(clazz);
 
-        if (isResourceMethod && hasControllerAnnotation) {
+        if (ControllerUtils.isControllerMethod(method.getJavaMember())) {
 
             log.log(Level.FINE, "Found controller method: {0}#{1}", new Object[]{
                 type.getJavaClass().getName(),

--- a/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
+++ b/core/src/main/java/org/eclipse/krazo/lifecycle/RequestLifecycle.java
@@ -41,6 +41,8 @@ public class RequestLifecycle {
     @Inject
     private MvcContextImpl mvc;
 
+    private boolean controllerExecuted = false;
+
     public void beforeAll(ContainerRequestContext context) {
 
         // initialize request locale
@@ -54,12 +56,19 @@ public class RequestLifecycle {
         eventDispatcher.fireBeforeControllerEvent();
         try {
 
-            return controllerMethod.call();
+            Object result = controllerMethod.call();
+            controllerExecuted = true;
+
+            return result;
 
         } finally {
             eventDispatcher.fireAfterControllerEvent();
         }
 
+    }
+
+    public boolean isControllerExecuted() {
+        return controllerExecuted;
     }
 
 }

--- a/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
@@ -171,9 +171,17 @@ public final class AnnotationUtils {
      * @return outcome of test.
      */
     static boolean hasMvcOrJaxrsAnnotations(Method method) {
-        return Arrays.stream(method.getDeclaredAnnotations()).anyMatch(a -> {
-            final String an = a.annotationType().getName();
-            return an.startsWith("javax.mvc.") || an.startsWith("javax.ws.rs.");
-        });
+        return hasMvcAnnotations(method) || hasJaxrsAnnotations(method);
     }
+
+    static boolean hasJaxrsAnnotations(Method method) {
+        return Arrays.stream(method.getDeclaredAnnotations())
+            .anyMatch(a -> a.annotationType().getName().startsWith("javax.ws.rs."));
+    }
+
+    static boolean hasMvcAnnotations(Method method) {
+        return Arrays.stream(method.getDeclaredAnnotations())
+            .anyMatch(a -> a.annotationType().getName().startsWith("javax.mvc."));
+    }
+
 }

--- a/core/src/main/java/org/eclipse/krazo/util/ControllerUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/ControllerUtils.java
@@ -64,8 +64,8 @@ public final class ControllerUtils {
         if (hasDeclaredRequestMethodAnnotation(method)) {
             return true;
         }
-        // inheritance disabled if other MVC or JAX-RS annotations found
-        if (AnnotationUtils.hasMvcOrJaxrsAnnotations(method)) {
+        // inheritance disabled if other JAX-RS annotations found
+        if (AnnotationUtils.hasJaxrsAnnotations(method)) {
             return false;
         }
         // check all super classes

--- a/examples/exceptions/pom.xml
+++ b/examples/exceptions/pom.xml
@@ -32,4 +32,11 @@
     <build>
         <finalName>test-exceptions</finalName>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.krazo</groupId>
+            <artifactId>krazo-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/HelloController.java
+++ b/examples/exceptions/src/main/java/org/eclipse/krazo/test/exceptions/HelloController.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.krazo.test.exceptions;
 
+import org.eclipse.krazo.engine.Viewable;
+
 import javax.mvc.Controller;
 import javax.mvc.View;
 import javax.ws.rs.ClientErrorException;
@@ -70,7 +72,9 @@ public class HelloController {
     public static class GlobalExceptionMapper implements ExceptionMapper<ClientErrorException> {
         @Override
         public Response toResponse(ClientErrorException exception) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("hello.jsp").build();
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(new Viewable("hello.jsp"))
+                .build();
         }
     }
 }

--- a/examples/exceptions/src/test/java/org/eclipse/krazo/test/exceptions/ExceptionsIT.java
+++ b/examples/exceptions/src/test/java/org/eclipse/krazo/test/exceptions/ExceptionsIT.java
@@ -59,7 +59,7 @@ public class ExceptionsIT {
     public void testNotFound() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/exceptions/not_found");
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
-        assertTrue(it.next().asText().contains("Hello World"));
+        assertFalse(it.next().asText().contains("Hello World"));
     }
 
     @Test

--- a/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/HelloController.java
+++ b/examples/view-annotation/src/main/java/org/eclipse/krazo/test/view/HelloController.java
@@ -103,7 +103,7 @@ public class HelloController {
     }
 
     /**
-     * Void method that throws a ForbiddenException. View 'hello.jsp' should be rendered.
+     * Void method that throws a ForbiddenException. View 'hello.jsp' should be ignored.
      */
     @GET
     @Path("void/forbidden")
@@ -123,7 +123,7 @@ public class HelloController {
     }
 
     /**
-     * Method that throws a ForbiddenException. View 'hello.jsp' should be rendered.
+     * Method that throws a ForbiddenException. View 'hello.jsp' should be ignored.
      */
     @GET
     @Path("string/forbidden")

--- a/examples/view-annotation/src/test/java/org/eclipse/krazo/test/view/ViewAnnotationIT.java
+++ b/examples/view-annotation/src/test/java/org/eclipse/krazo/test/view/ViewAnnotationIT.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -103,7 +104,7 @@ public class ViewAnnotationIT {
         final HtmlPage page = webClient.getPage(webUrl + "resources/void/forbidden");
         assertThat(page.getWebResponse().getStatusCode(), is(403));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
-        assertTrue(it.next().asText().contains("Hello World"));
+        assertFalse(it.next().asText().contains("Hello World"));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class ViewAnnotationIT {
         final HtmlPage page = webClient.getPage(webUrl + "resources/string/forbidden");
         assertThat(page.getWebResponse().getStatusCode(), is(403));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
-        assertTrue(it.next().asText().contains("Hello World"));
+        assertFalse(it.next().asText().contains("Hello World"));
     }
 
     @Test

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -144,7 +144,6 @@
             <groupId>org.eclipse.krazo</groupId>
             <artifactId>krazo-core</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Arquillian -->

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/FailingController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/FailingController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+import javax.inject.Inject;
+import javax.mvc.Controller;
+import javax.mvc.Models;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Controller
+@Path("/mappers")
+public class FailingController {
+
+    @Inject
+    private Models models;
+
+    @GET
+    @Path("/success")
+    public String success() {
+        models.put("message", "Controller was executed without errors!");
+        return "success.jsp";
+    }
+
+    @GET
+    @Path("/fail-plain-text")
+    public String failPlainText() {
+        throw new PlainTextException("Error thrown by controller");
+    }
+
+    @GET
+    @Path("/fail-mvc-view")
+    public String failMvcView() {
+        throw new MvcViewException("Error thrown by controller");
+    }
+
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MvcViewException.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MvcViewException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+public class MvcViewException extends RuntimeException {
+
+    private static final long serialVersionUID = 5452675105452096791L;
+
+    public MvcViewException(String message) {
+        super(message);
+    }
+
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MvcViewExceptionMapper.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MvcViewExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+import org.eclipse.krazo.core.ModelsImpl;
+import org.eclipse.krazo.engine.Viewable;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class MvcViewExceptionMapper implements ExceptionMapper<MvcViewException> {
+
+    @Override
+    public Response toResponse(MvcViewException exception) {
+
+        ModelsImpl models = new ModelsImpl();
+        models.put("error", exception.getMessage());
+        Viewable viewable = new Viewable("mvc-error.jsp", models);
+
+        return Response.status(492)
+            .entity(viewable)
+            .build();
+    }
+
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/MyApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("mvc")
+public class MyApplication extends Application {
+
+    // nothing
+
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/PlainTextException.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/PlainTextException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+public class PlainTextException extends RuntimeException {
+
+    private static final long serialVersionUID = 5452675105452096791L;
+
+    public PlainTextException(String message) {
+        super(message);
+    }
+
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mapper/PlainTextExceptionMapper.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mapper/PlainTextExceptionMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class PlainTextExceptionMapper implements ExceptionMapper<PlainTextException> {
+
+    @Override
+    public Response toResponse(PlainTextException exception) {
+        return Response.status(491)
+            .type(MediaType.TEXT_PLAIN_TYPE)
+            .entity("Exception caught: " + exception.getMessage())
+            .build();
+    }
+
+}

--- a/testsuite/src/test/java/org/eclipse/krazo/test/mapper/ExceptionMapperIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/mapper/ExceptionMapperIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.test.mapper;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import org.eclipse.krazo.test.util.WebArchiveBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Arquillian.class)
+public class ExceptionMapperIT {
+
+    @ArquillianResource
+    private URL baseURL;
+
+    private WebClient webClient;
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        return new WebArchiveBuilder()
+            .addPackage("org.eclipse.krazo.test.mapper")
+            .addView(new StringAsset("<h1>${message}</h1>"), "success.jsp")
+            .addView(new StringAsset("<h1>Exception caught: ${error}</h1>"), "mvc-error.jsp")
+            .addBeansXml()
+            .build();
+    }
+
+    @Before
+    public void before() {
+        webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(false);
+    }
+
+    @Test
+    public void testControllerHappyPath() throws IOException {
+
+        Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/success");
+        WebResponse webResponse = page.getWebResponse();
+
+        assertThat(webResponse.getStatusCode(), equalTo(200));
+        assertThat(webResponse.getContentType(), startsWith("text/html"));
+        assertThat(webResponse.getContentAsString(),
+            containsString("<h1>Controller was executed without errors!</h1>"));
+
+    }
+
+    @Test
+    public void testHandledByPlainTextMapper() throws IOException {
+
+        Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/fail-plain-text");
+        WebResponse webResponse = page.getWebResponse();
+
+        assertThat(webResponse.getStatusCode(), equalTo(491));
+        assertThat(webResponse.getContentType(), startsWith("text/plain"));
+        assertThat(webResponse.getContentAsString(),
+            equalTo("Exception caught: Error thrown by controller"));
+
+    }
+
+    @Test
+    public void testHandledByMvcViewMapper() throws IOException {
+
+        Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/fail-mvc-view");
+        WebResponse webResponse = page.getWebResponse();
+
+        assertThat(webResponse.getStatusCode(), equalTo(492));
+        assertThat(webResponse.getContentType(), startsWith("text/html"));
+        assertThat(webResponse.getContentAsString(),
+            containsString("<h1>Exception caught: Error thrown by controller</h1>"));
+
+    }
+
+}


### PR DESCRIPTION
This pull requests contains the refactoring described in #104. Actually the change is quite simple. The request-scoped`RequestLifecycle` class just tracks if the controller was invoked successfully and the `VewiResponseFilter` only runs if this is the case. 

The PR contains integration tests which checks 3 different scenarios:

  * If the controller execution is successful, the request is processed just like before.
  * If the controller throws an exception and an exception mapper creates a plain text response, this must work exactly like in a plain JAX-RS application (and NOT trigger a view engine lookup)
  * If the controller throws an exception and an exception mapper wants to render an MVC view, it can simple use a `Viewable` as the entity.

I guess this should cover all the relevant cases. The integration test actually reproduces the exact case described in #34. I don't have an explicit coverage for #91 yet, but I'm pretty sure that this is fixed as well.

The PR also contains another fix: The `AroundControllerInterceptor` wasn't detecting PATCH methods and was not implementing the MVC / JAX-RS annotation inheritance rules correctly. This caused test failures after my refactoring. The fix was easy, because there is already a utility method which checks if a method is a controller method.

Let me know what you think.