### PR TITLE
Added code format reference to CONTRIBUTING.md (fixes #105)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ The project maintains the following source code repositories
 
 * https://github.com/eclipse-ee4j/krazo
 
+Eclipse Krazo uses the Eclipse EE4J code format rules available here:
+
+* https://github.com/eclipse-ee4j/ee4j/tree/master/codestyle
+
 ## Eclipse Contributor Agreement
 
 Before your contribution can be accepted by the project team contributors must


### PR DESCRIPTION
This pull request adds the link to the EE4J code format rules to the CONTRIBUTING.md file