### PR TITLE
Add custom resource loader for Velocity view engine

### DIFF
--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -31,9 +31,9 @@
     <name>Eclipse Krazo Velocity Extension</name>
     <dependencies>
         <dependency>
-            <groupId>org.apache.velocity.tools</groupId>
-            <artifactId>velocity-tools-view</artifactId>
-            <version>3.0</version>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/DefaultVelocityEngineProducer.java
+++ b/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/DefaultVelocityEngineProducer.java
@@ -18,9 +18,8 @@
  */
 package org.eclipse.krazo.ext.velocity;
 
-import org.eclipse.krazo.engine.ViewEngineConfig;
 import org.apache.velocity.app.VelocityEngine;
-import org.apache.velocity.tools.view.WebappResourceLoader;
+import org.eclipse.krazo.engine.ViewEngineConfig;
 
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -41,7 +40,7 @@ public class DefaultVelocityEngineProducer {
     public VelocityEngine getVelocityEngine() {
         VelocityEngine velocityEngine = new VelocityEngine();
         velocityEngine.setProperty("resource.loader", "webapp");
-        velocityEngine.setProperty("webapp.resource.loader.class", WebappResourceLoader.class.getCanonicalName());
+        velocityEngine.setProperty("webapp.resource.loader.class", ServletContextResourceLoader.class.getCanonicalName());
         velocityEngine.setApplicationAttribute("javax.servlet.ServletContext", servletContext);
         velocityEngine.init();
         return velocityEngine;

--- a/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/ServletContextResourceLoader.java
+++ b/ext/velocity/src/main/java/org/eclipse/krazo/ext/velocity/ServletContextResourceLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.krazo.ext.velocity;
+
+import org.apache.velocity.exception.ResourceNotFoundException;
+import org.apache.velocity.runtime.resource.Resource;
+import org.apache.velocity.runtime.resource.loader.ResourceLoader;
+import org.apache.velocity.util.ExtProperties;
+
+import javax.servlet.ServletContext;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Simple implementation of {@link ResourceLoader} for loading resources from {@link ServletContext}
+ *
+ * @author Christian Kaltepoth
+ */
+public class ServletContextResourceLoader extends ResourceLoader {
+
+    private ServletContext servletContext;
+
+    @Override
+    public void init(ExtProperties configuration) {
+        servletContext = (ServletContext) rsvc.getApplicationAttribute(ServletContext.class.getName());
+    }
+
+    @Override
+    public Reader getResourceReader(String source, String encoding) throws ResourceNotFoundException {
+        try {
+
+            InputStream stream = servletContext.getResourceAsStream(source);
+            if (stream != null) {
+                return new InputStreamReader(stream, encoding);
+            }
+            return null;
+
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean isSourceModified(Resource resource) {
+        return false;
+    }
+
+    @Override
+    public long getLastModified(Resource resource) {
+        return 0;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,20 +104,6 @@
         <url>https://github.com/eclipse-ee4j/krazo/issues</url>
     </issueManagement>
 
-    <dependencyManagement>
-        <dependencies>
-
-            <!-- Manually upgrade commons-beanutils to fix vulnerability CVE-2019-10086 -->
-            <!-- Currently, the vulnerable version is only used by org.apache.velocity.tools:velocity-tools-view. -->
-            <!-- When the common-beanutils are upgraded in this dependency, we can remove this workaround. -->
-            <dependency>
-                <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
This PR removes our dependency on `velocity-tools-view`. I added a custom resource loader which replaces the one we used from the old dependency. Our new custom implementation doesn't support any caching at the moment, but I don't think that this is a real problem. Especially because most of the other 3rd party view engines also don't support a caching mechanism.

I also updated Velocity Engine from 2.0 to 2.1. There is a [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21009) which was already approved

I was also able to remove the `<dependencyManagement>` entry we needed due to the outdated `commons-beanutils` dependency in Velocity Tools.

