### PR TITLE
Updated Java EE API with Jakarta EE version

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -35,9 +35,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -50,9 +50,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -55,9 +55,9 @@
 
         <!-- Maybe this should be moved to the TCK pom? -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -130,9 +130,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>${javaee.version}</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
We currently don't have a CQ for the Java EE 7 dependency. And as we need Java/Jakarta EE 8 anyway, let's update this now.