### PR TITLE
Feature view resolution extension point

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -177,10 +177,16 @@
         </dependency>
         <dependency>
           <groupId>org.hibernate</groupId>
-          <artifactId>hibernate-validator-cdi</artifactId>
+          <artifactId>hibernate-validator</artifactId>
           <version>5.4.1.Final</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+			<groupId>com.fasterxml</groupId>
+			<artifactId>classmate</artifactId>
+			<version>1.5.1</version>
+			<scope>test</scope>
+		</dependency>
         <!-- Including some EL implementation required for Hibernate Validator -->
         <dependency>
           <groupId>org.glassfish</groupId>

--- a/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
@@ -103,6 +103,7 @@ public class KrazoCdiExtension implements Extension {
                 ModelsImpl.class,
                 ViewableWriter.class,
                 ViewResponseFilter.class,
+                DefaultViewPathResolver.class,
                 
                 // lifecycle
                 EventDispatcher.class,

--- a/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
@@ -1,12 +1,9 @@
 package org.eclipse.krazo.core;
 
-import static org.eclipse.krazo.util.AnnotationUtils.getAnnotation;
-
 import java.lang.reflect.Method;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
-import javax.mvc.View;
 
 @Default
 @ApplicationScoped
@@ -14,11 +11,7 @@ public class DefaultViewPathResolver implements ViewPathResolver {
 
     @Override
     public String pathFor(Method method) {
-	View an = getAnnotation(method, View.class);
-        if (an == null) {
-            an = getAnnotation(method.getDeclaringClass(), View.class);
-        }
-        return (an != null ? an.value() : null);
+        return null;
     }
 
 }

--- a/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
@@ -5,10 +5,22 @@ import java.lang.reflect.Method;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 
+
+/**
+ * Default view path resolver that keeps default compatibility
+ *
+ * @author Jonatan Lemes
+ */
 @Default
 @ApplicationScoped
 public class DefaultViewPathResolver implements ViewPathResolver {
 
+    
+    /**
+     * Default implementation that keeps default compatibility
+     * @param Controller method thats is current executing {@link java.lang.reflect.Method}.
+     * @return resolved view name path.
+     */
     @Override
     public String pathFor(Method method) {
         return null;

--- a/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/core/DefaultViewPathResolver.java
@@ -1,0 +1,24 @@
+package org.eclipse.krazo.core;
+
+import static org.eclipse.krazo.util.AnnotationUtils.getAnnotation;
+
+import java.lang.reflect.Method;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.mvc.View;
+
+@Default
+@ApplicationScoped
+public class DefaultViewPathResolver implements ViewPathResolver {
+
+    @Override
+    public String pathFor(Method method) {
+	View an = getAnnotation(method, View.class);
+        if (an == null) {
+            an = getAnnotation(method.getDeclaringClass(), View.class);
+        }
+        return (an != null ? an.value() : null);
+    }
+
+}

--- a/core/src/main/java/org/eclipse/krazo/core/ViewPathResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewPathResolver.java
@@ -2,6 +2,19 @@ package org.eclipse.krazo.core;
 
 import java.lang.reflect.Method;
 
+
+/**
+ * Interface thats provide way to resolve view names after try looking for @View
+ *
+ * @author Jonatan Lemes
+ */
 public interface ViewPathResolver {
+    
+    /**
+     * Return a resolved view name based on method infos. If returns null throws Exception based on spec 
+     *
+     * @param {@link java.lang.reflect.Method} of controller thats is current executing.
+     * @return resolved view name path.
+     */
     public String pathFor(Method method);
 }

--- a/core/src/main/java/org/eclipse/krazo/core/ViewPathResolver.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewPathResolver.java
@@ -1,0 +1,7 @@
+package org.eclipse.krazo.core;
+
+import java.lang.reflect.Method;
+
+public interface ViewPathResolver {
+    public String pathFor(Method method);
+}

--- a/core/src/test/java/org/eclipse/krazo/core/DefaultViewPathResolverTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/DefaultViewPathResolverTest.java
@@ -10,59 +10,59 @@ import org.junit.Test;
 public class DefaultViewPathResolverTest {
 
     private ViewPathResolver viewPathResolver;
-    
+
     @Before
     public void before() {
-	viewPathResolver = new DefaultViewPathResolver();
+        viewPathResolver = new DefaultViewPathResolver();
     }
-    
+
     @Test
     public void testDefaultBehaviour() throws NoSuchMethodException, SecurityException {
-	Class<MyTestClass> clazz = MyTestClass.class;
-        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
+        Class<MyTestClass> clazz = MyTestClass.class;
+        assertNull(viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
         assertNull(viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod2")));
     }
-    
+
     @Test
     public void testDefaultBehaviourWithAnnotedClass() throws NoSuchMethodException, SecurityException {
-	Class<MyTestClass2> clazz = MyTestClass2.class;
-        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
-        assertEquals("b.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod2")));
+        Class<MyTestClass2> clazz = MyTestClass2.class;
+        assertNull(viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
+        assertNull(viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod2")));
     }
-    
+
     @Test
     public void testDefaultBehaviourWithInheritClass() throws NoSuchMethodException, SecurityException {
-	Class<MyTestClass3> clazz = MyTestClass3.class;
-        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getMethod("someMethod")));
-        assertEquals("b.jsp",viewPathResolver.pathFor(clazz.getMethod("someMethod2")));
+        Class<MyTestClass3> clazz = MyTestClass3.class;
+        assertNull(viewPathResolver.pathFor(clazz.getMethod("someMethod")));
+        assertNull(viewPathResolver.pathFor(clazz.getMethod("someMethod2")));
     }
-    
+
     private class MyTestClass {
 
-	@View("a.jsp")
-	public void someMethod() {
-	    
-	}
-	
-	public void someMethod2() {
-	    
-	}
+        @View("a.jsp")
+        public void someMethod() {
+
+        }
+
+        public void someMethod2() {
+
+        }
     }
-    
+
     @View("b.jsp")
     private class MyTestClass2 {
 
-	@View("a.jsp")
-	public void someMethod() {
-	    
-	}
-	
-	public void someMethod2() {
-	    
-	}
+        @View("a.jsp")
+        public void someMethod() {
+
+        }
+
+        public void someMethod2() {
+
+        }
     }
-    
+
     private class MyTestClass3 extends MyTestClass2 {
-	
+
     }
 }

--- a/core/src/test/java/org/eclipse/krazo/core/DefaultViewPathResolverTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/DefaultViewPathResolverTest.java
@@ -1,0 +1,68 @@
+package org.eclipse.krazo.core;
+
+import static org.junit.Assert.*;
+
+import javax.mvc.View;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultViewPathResolverTest {
+
+    private ViewPathResolver viewPathResolver;
+    
+    @Before
+    public void before() {
+	viewPathResolver = new DefaultViewPathResolver();
+    }
+    
+    @Test
+    public void testDefaultBehaviour() throws NoSuchMethodException, SecurityException {
+	Class<MyTestClass> clazz = MyTestClass.class;
+        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
+        assertNull(viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod2")));
+    }
+    
+    @Test
+    public void testDefaultBehaviourWithAnnotedClass() throws NoSuchMethodException, SecurityException {
+	Class<MyTestClass2> clazz = MyTestClass2.class;
+        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod")));
+        assertEquals("b.jsp",viewPathResolver.pathFor(clazz.getDeclaredMethod("someMethod2")));
+    }
+    
+    @Test
+    public void testDefaultBehaviourWithInheritClass() throws NoSuchMethodException, SecurityException {
+	Class<MyTestClass3> clazz = MyTestClass3.class;
+        assertEquals("a.jsp",viewPathResolver.pathFor(clazz.getMethod("someMethod")));
+        assertEquals("b.jsp",viewPathResolver.pathFor(clazz.getMethod("someMethod2")));
+    }
+    
+    private class MyTestClass {
+
+	@View("a.jsp")
+	public void someMethod() {
+	    
+	}
+	
+	public void someMethod2() {
+	    
+	}
+    }
+    
+    @View("b.jsp")
+    private class MyTestClass2 {
+
+	@View("a.jsp")
+	public void someMethod() {
+	    
+	}
+	
+	public void someMethod2() {
+	    
+	}
+    }
+    
+    private class MyTestClass3 extends MyTestClass2 {
+	
+    }
+}

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -219,7 +219,7 @@ public class ViewResponseFilterTest {
     }
 
     private class MyTestClass3 extends MyTestClass2 {
-
+ 
     }
 
 }

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -18,55 +18,207 @@
  */
 package org.eclipse.krazo.core;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import javax.enterprise.event.Event;
+import javax.mvc.View;
+import javax.mvc.event.MvcEvent;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.Response.StatusType;
+
+import org.eclipse.krazo.KrazoConfig;
+import org.eclipse.krazo.engine.Viewable;
+import org.eclipse.krazo.lifecycle.RequestLifecycle;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test for ViewResponseFilter
  *
  * @author Dmytro Maidaniuk
+ * @author Jonatan Lemes
  */
-@RunWith(value = Parameterized.class)
+
 public class ViewResponseFilterTest {
 
-    private String viewName;
+    private ViewResponseFilter viewResponseFilter;
 
-    private String defaultExtension;
+    private ContainerResponseContext containerResponseContext;
 
-    private String expectedViewName;
+    private ContainerRequestContext containerRequestContext;
 
-    public ViewResponseFilterTest(String viewName,
-                                  String defaultExtension,
-                                  String expectedViewName) {
-        this.viewName = viewName;
-        this.defaultExtension = defaultExtension;
-        this.expectedViewName = expectedViewName;
+    private ViewPathResolver viewPathResolver;
+
+    private RequestLifecycle requestLifecycle;
+
+    private KrazoConfig krazoConfig;
+
+    private Messages messages;
+
+    private HttpServletRequest request;
+
+    private ResourceInfo resourceInfo;
+
+    private UriInfo uriInfo;
+
+    private Event<MvcEvent> dispatcher;
+
+    private StatusType statusType;
+
+    @Before
+    public void before() {
+        statusType = createMock(StatusType.class);
+        uriInfo = createMock(UriInfo.class);
+        resourceInfo = createMock(ResourceInfo.class);
+        request = createMock(HttpServletRequest.class);
+        dispatcher = createMock(Event.class);
+        messages = createMock(Messages.class);
+        krazoConfig = createMock(KrazoConfig.class);
+        requestLifecycle = createMock(RequestLifecycle.class);
+        viewPathResolver = new DefaultViewPathResolver();
+        containerResponseContext = createMock(ContainerResponseContext.class);
+        containerRequestContext = createMock(ContainerRequestContext.class);
+        viewResponseFilter = new ViewResponseFilter(uriInfo, resourceInfo, request, dispatcher, messages, krazoConfig, requestLifecycle, viewPathResolver);
     }
 
-    @Parameters
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {"main.jsp", "jsp", "main.jsp"},
-            {"main", "jsp", "main.jsp"},
-            {"main", null, "main"},
-            {"main", "", "main"},
-            {"redirect:some.jsp", "jsp", "redirect:some.jsp"},
-            {"react:some", "jsp", "react:some.jsp"},
-            {"main.", "jsp", "main."}
+    public static Collection<String[]> data() {
+        return Arrays.asList(new String[][] {
+                { "main.jsp", "jsp", "main.jsp" },
+                { "main", "jsp", "main.jsp" },
+                { "main", null, "main" },
+                { "main", "", "main" },
+                { "redirect:some.jsp", "jsp", "redirect:some.jsp" },
+                { "react:some", "jsp", "react:some.jsp" },
+                { "main.", "jsp", "main." }
         });
     }
 
     @Test
     public void testAppendExtensionIfRequired() {
-        String actualViewName = ViewResponseFilter.appendExtensionIfRequired(viewName, defaultExtension);
-        assertEquals(expectedViewName, actualViewName);
+        for (String[] data : data()) {
+            String viewName = data[0];
+            String defaultExtension = data[1];
+            String expectedViewName = data[2];
+            String actualViewName = ViewResponseFilter.appendExtensionIfRequired(viewName, defaultExtension);
+            assertEquals(expectedViewName, actualViewName);
+        }
+    }
+
+    private Viewable mockBehaviours(Class<?> clazz, Method method) throws IOException {
+
+        ViewableHolder viewableHolder = new ViewableHolder();
+
+        expect(request.getAttribute(ViewResponseFilter.FILTER_EXECUTED_KEY)).andReturn(null);
+        request.setAttribute(anyString(), anyBoolean());
+        expect(requestLifecycle.isControllerExecuted()).andReturn(true);
+        expect(requestLifecycle.getControllerMethod()).andReturn(method);
+        expect(containerResponseContext.getEntity()).andReturn(null);
+        expect(statusType.getStatusCode()).andReturn(Response.Status.NO_CONTENT.getStatusCode());
+        expect(containerResponseContext.getStatusInfo()).andReturn(statusType);
+        expect(resourceInfo.getResourceMethod()).andReturn(method);
+        resourceInfo.getResourceClass();
+        expectLastCall().andReturn(clazz);
+
+        containerResponseContext.setEntity(anyObject(Viewable.class), anyObject(), anyObject());
+        expectLastCall().andAnswer(() -> {
+            viewableHolder.viewable = (Viewable) getCurrentArguments()[0];
+            return null;
+        }).times(1);
+        containerResponseContext.setStatusInfo(anyObject());
+        expect(containerResponseContext.getEntity()).andReturn(null);
+
+        replay(statusType);
+        replay(resourceInfo);
+        replay(request);
+        replay(requestLifecycle);
+        replay(containerResponseContext);
+
+        viewResponseFilter.filter(containerRequestContext, containerResponseContext);
+
+        return viewableHolder.viewable;
+    }
+
+    @Test
+    public void testDefaultBehaviourWithNoException() throws Exception {
+        Class<MyTestClass> clazz = MyTestClass.class;
+        assertEquals("a.jsp", mockBehaviours(clazz, clazz.getDeclaredMethod("someMethod")).getView());
+    }
+
+    @Test(expected = ServerErrorException.class)
+    public void testDefaultBehaviourWithException() throws Exception {
+        Class<MyTestClass> clazz = MyTestClass.class;
+        assertEquals("a.jsp", mockBehaviours(clazz, clazz.getDeclaredMethod("someMethod2")).getView());
+    }
+
+    @Test
+    public void testDefaultBehaviourWithAnnotedClassWithAnnotation() throws Exception {
+        Class<MyTestClass2> clazz = MyTestClass2.class;
+        assertEquals("a.jsp", mockBehaviours(clazz, clazz.getDeclaredMethod("someMethod")).getView());
+        
+    }
+    
+    @Test
+    public void testDefaultBehaviourWithAnnotedClassWithoutAnnotation() throws Exception {
+        Class<MyTestClass2> clazz = MyTestClass2.class;
+        assertEquals("b.jsp", mockBehaviours(clazz, clazz.getDeclaredMethod("someMethod2")).getView());
+    }
+
+    @Test
+    public void testDefaultBehaviourWithInheritClassMethod1() throws Exception {
+        Class<MyTestClass3> clazz = MyTestClass3.class;
+        assertEquals("a.jsp", mockBehaviours(clazz, clazz.getMethod("someMethod")).getView());
+    }
+    
+    @Test
+    public void testDefaultBehaviourWithInheritClassMethod2() throws Exception {
+        Class<MyTestClass3> clazz = MyTestClass3.class;
+        assertEquals("b.jsp", mockBehaviours(clazz, clazz.getMethod("someMethod2")).getView());
+    }
+
+    private class ViewableHolder {
+        public Viewable viewable;
+    }
+
+    private class MyTestClass {
+
+        @View("a.jsp")
+        public void someMethod() {
+
+        }
+
+        public void someMethod2() {
+
+        }
+    }
+
+    @View("b.jsp")
+    private class MyTestClass2 {
+
+        @View("a.jsp")
+        public void someMethod() {
+
+        }
+
+        public void someMethod2() {
+
+        }
+    }
+
+    private class MyTestClass3 extends MyTestClass2 {
+
     }
 
 }

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -91,7 +91,10 @@ public class ViewResponseFilterTest {
         viewPathResolver = new DefaultViewPathResolver();
         containerResponseContext = createMock(ContainerResponseContext.class);
         containerRequestContext = createMock(ContainerRequestContext.class);
-        viewResponseFilter = new ViewResponseFilter(uriInfo, resourceInfo, request, dispatcher, messages, krazoConfig, requestLifecycle, viewPathResolver);
+        viewResponseFilter = new ViewResponseFilter(dispatcher, messages, krazoConfig, requestLifecycle, viewPathResolver);
+        viewResponseFilter.setRequest(request);
+        viewResponseFilter.setResourceInfo(resourceInfo);
+        viewResponseFilter.setUriInfo(uriInfo);
     }
 
     public static Collection<String[]> data() {

--- a/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/core/ViewResponseFilterTest.java
@@ -139,6 +139,7 @@ public class ViewResponseFilterTest {
         }).times(1);
         containerResponseContext.setStatusInfo(anyObject());
         expect(containerResponseContext.getEntity()).andReturn(null);
+        expect(containerResponseContext.getStatus()).andReturn(200);
 
         replay(statusType);
         replay(resourceInfo);

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -18,7 +18,6 @@
  */
 package org.eclipse.krazo.util;
 
-import org.eclipse.krazo.core.DefaultViewPathResolver;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -62,7 +62,7 @@ public class AnnotationUtilsTest {
 	@Before
 	public void before() {
 
-		Weld weld = new Weld().addBeanClass(DefaultViewPathResolver.class);
+		Weld weld = new Weld();
 		container = weld.initialize();
 
 		injectFields(this, container.getBeanManager());

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.krazo.util;
 
+import org.eclipse.krazo.core.DefaultViewPathResolver;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.After;
@@ -61,7 +62,7 @@ public class AnnotationUtilsTest {
 	@Before
 	public void before() {
 
-		Weld weld = new Weld();
+		Weld weld = new Weld().addBeanClass(DefaultViewPathResolver.class);
 		container = weld.initialize();
 
 		injectFields(this, container.getBeanManager());


### PR DESCRIPTION
Please consider give some point of extension as how krazo resolve views names. Extension point like this gives to a developer some flexibility how configure views routes, like adding some Convention Over Configuration behaviours.  

One example of change default behaviour is:

```java
@Alternative
@Priority(ViewEngine.PRIORITY_FRAMEWORK)
public class MyAnotherPathViewResolver implements ViewPathResolver {

    @Override
    public String pathFor(Method method) {
	return pathForClass(method) + "/" + pathForMethod(method) + ".jsp";
    }

    private String pathForMethod(Method method) {
	String path = path(method);
	if(!StringUtils.isEmpty(path)) {
	    return path;
	} else {
	    return method.getName();
	}
    }

    private String pathForClass(Method method) {
	Class<?> clazz = method.getDeclaringClass();
	String path = path(clazz);
	if(!StringUtils.isEmpty(path)) {
	    return path;
	} else {
	    return StringUtils.uncapitalize(clazz.getSimpleName().replace("Controller", "").toLowerCase());
	}
    }
    
    private String path(AnnotatedElement annotatedElement) {
	Path path = annotatedElement.getAnnotation(Path.class);
	if(path != null && !"/".equals(path.value())) {
	    return path.value();
	}
	return null;
    }

}
```

This one simplify way how krazo resolve view without change mvc spec behaviour (its just for provide some kind of extension point). 

Please let me know if i can help with more informations. 

