### PR TITLE
Update TCK version to avoid dependency problems during build

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
 
-        <tck.version>1.0-SNAPSHOT</tck.version>
+        <tck.version>1.0.0-RC1</tck.version>
 
         <!-- We don't deploy this module, because the TCK isn't in Maven Central yet -->
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
At the moment, our build isn't able to be executed with `mvn install` without having the TCK installed locally. To avoid this, I set the version to the currently released TCK artifact, so this problem doesn't occur anymore.

Signed-off-by: Erdle, Tobias <tobias.erdle@innoq.com>