### PR TITLE
Replace arquillian-drone with plain htmlunit

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -55,13 +55,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian.extension</groupId>
-                <artifactId>arquillian-drone-bom</artifactId>
-                <version>2.3.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <!-- Define optional dependencies for the tests below -->
             <!-- EXT -->
@@ -161,13 +154,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.graphene</groupId>
-            <artifactId>graphene-webdriver</artifactId>
-            <version>2.3.1</version>
-            <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/src/test/java/org/eclipse/krazo/test/MvcIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/MvcIT.java
@@ -18,18 +18,16 @@
  */
 package org.eclipse.krazo.test;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.eclipse.krazo.test.util.WebArchiveBuilder;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -51,8 +49,16 @@ public class MvcIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "thymeleaf")
     public static Archive createDeployment() {
@@ -65,12 +71,12 @@ public class MvcIT {
 
     @Test
     public void test() throws Exception {
-        webDriver.get(baseURL + "resources/mvc");
+        final HtmlPage page = webClient.getPage(baseURL + "resources/mvc");
 
-        assertEquals(baseURL.getPath() + "resources", webDriver.findElement(By.id("basePath")).getText());
-        assertEquals(CSRF_PARAM, webDriver.findElement(By.id("csrf")).getText());
-        assertEquals("<&>", webDriver.findElement(By.id("encoders")).getText());
-        assertEquals("true", webDriver.findElement(By.id("config")).getText());
+        assertEquals(baseURL.getPath() + "resources", page.getElementById("basePath").getTextContent());
+        assertEquals(CSRF_PARAM, page.getElementById("csrf").getTextContent());
+        assertEquals("<&>", page.getElementById("encoders").getTextContent());
+        assertEquals("true", page.getElementById("config").getTextContent());
     }
 }
 

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/AsciiDocIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/AsciiDocIT.java
@@ -18,18 +18,19 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.helper.annotation.IgnoreOnWildfly;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -48,11 +49,19 @@ public class AsciiDocIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "asciidoc")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.asciidoc")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.adoc").toFile(), "hello.adoc")
@@ -62,9 +71,9 @@ public class AsciiDocIT {
     }
 
     @Test
-    public void testView1() {
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final String h2 = webDriver.findElement(By.tagName("h2")).getText();
+    public void testView1() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final String h2 = page.getElementsByTagName("h2").get(0).getTextContent();
         assertTrue(h2.contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/FreemarkerIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/FreemarkerIT.java
@@ -18,16 +18,16 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -42,11 +42,19 @@ public class FreemarkerIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "freemarker")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.freemarker")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.ftl").toFile(), "hello.ftl")
@@ -56,9 +64,9 @@ public class FreemarkerIT {
     }
 
     @Test
-    public void testView() {
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final String h1 = webDriver.findElement(By.tagName("h1")).getText();
+    public void testView() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final String h1 = page.getElementsByTagName("h1").get(0).getTextContent();
         assertTrue(h1.contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/HandlebarsIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/HandlebarsIT.java
@@ -18,17 +18,17 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -49,8 +49,16 @@ public class HandlebarsIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "handlebars")
     public static Archive createDeployment() {
@@ -63,9 +71,9 @@ public class HandlebarsIT {
     }
 
     @Test
-    public void testView1() {
-        webDriver.navigate().to(baseURL + "resources/person");
-        final List<WebElement> divs = webDriver.findElements(By.tagName("div"));
+    public void testView1() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/person");
+        final List<DomElement> divs = page.getElementsByTagName("div");
         assertEquals(3, divs.size());
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/JetbrickIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/JetbrickIT.java
@@ -18,19 +18,17 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Assert;
-import org.junit.Assume;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -45,11 +43,19 @@ public class JetbrickIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "jetbrick")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.jetbrick")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.jetx").toFile(), "hello.jetx")
@@ -59,10 +65,10 @@ public class JetbrickIT {
     }
 
     @Test
-    public void testView1() {
+    public void testView1() throws Exception {
         //FIXME: Jetbricks-Ext is broken if the container runs on Java 9 (and above)
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final WebElement h1 = webDriver.findElement(By.tagName("h1"));
-        assertTrue(h1.getText().contains("mvc"));
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final DomElement h1 = page.getElementsByTagName("h1").get(0);
+        assertTrue(h1.getTextContent().contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
@@ -81,6 +81,6 @@ public class Jsr223IT {
     @Category(IgnoreOnWildfly.class)
     public void testJython() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + "mvc/jython?name=Jython");
-        assertTrue(page.getTextContent().contains("Hello Jython"));
+        assertTrue(page.getBody().getTextContent().contains("Hello Jython"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/Jsr223IT.java
@@ -18,21 +18,23 @@
  */
 package org.eclipse.krazo.test.ext;
 
-import static org.junit.Assert.assertTrue;
-
-import java.net.URL;
-import java.nio.file.Paths;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.helper.annotation.IgnoreOnWildfly;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.WebDriver;
+
+import java.net.URL;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class Jsr223IT {
@@ -42,11 +44,19 @@ public class Jsr223IT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(name = "jsr223", testable = false)
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.jsr223")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/index.js").toFile(), "index.js")
@@ -58,9 +68,9 @@ public class Jsr223IT {
     }
 
     @Test
-    public void testNashorn() {
-        webDriver.navigate().to(baseURL + "mvc/nashorn?name=Nashorn");
-        assertTrue(webDriver.getPageSource().contains("Hello Nashorn"));
+    public void testNashorn() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "mvc/nashorn?name=Nashorn");
+        assertTrue(page.getBody().getTextContent().contains("Hello Nashorn"));
     }
 
     @Test
@@ -69,8 +79,8 @@ public class Jsr223IT {
     // in 2020 (EOL Python 2) we probably need to remove this test with Jython 2.7 anyway
     // and the above mentioned configuration effort would count for nothing.
     @Category(IgnoreOnWildfly.class)
-    public void testJython() {
-        webDriver.navigate().to(baseURL + "mvc/jython?name=Jython");
-        assertTrue(webDriver.getPageSource().contains("Hello Jython"));
+    public void testJython() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "mvc/jython?name=Jython");
+        assertTrue(page.getTextContent().contains("Hello Jython"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/JtwigIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/JtwigIT.java
@@ -18,23 +18,21 @@
  */
 package org.eclipse.krazo.test.ext;
 
-import static org.junit.Assert.assertEquals;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.eclipse.krazo.test.util.WebArchiveBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.net.URL;
 import java.nio.file.Paths;
 
-import org.eclipse.krazo.test.util.WebArchiveBuilder;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Test;
-
-import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit test for simple App.
@@ -47,8 +45,16 @@ public class JtwigIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "jtwig")
     public static Archive createDeployment() {
@@ -62,8 +68,8 @@ public class JtwigIT {
 
     @Test
     public void testView1() throws Exception {
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final String h1 = webDriver.findElement(By.tagName("h1")).getText();
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final String h1 = page.getElementsByTagName("h1").get(0).getTextContent();
         assertEquals("Hello mvc", h1.trim());
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/MustacheIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/MustacheIT.java
@@ -18,16 +18,17 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -42,11 +43,19 @@ public class MustacheIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "mustache")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.mustache")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.mustache").toFile(), "hello.mustache")
@@ -56,9 +65,9 @@ public class MustacheIT {
     }
 
     @Test
-    public void testView() {
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final String h1 = webDriver.findElement(By.tagName("h1")).getText();
+    public void testView() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final String h1 = page.getElementsByTagName("h1").get(0).getTextContent();
         assertTrue(h1.contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/StringTemplateIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/StringTemplateIT.java
@@ -18,17 +18,17 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -43,11 +43,19 @@ public class StringTemplateIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "stringtemplate")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.stringtemplate")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.st").toFile(), "hello.st")
@@ -57,9 +65,9 @@ public class StringTemplateIT {
     }
 
     @Test
-    public void testView1() {
-        webDriver.navigate().to(baseURL + "resources/hello?user=mvc");
-        final WebElement h1 = webDriver.findElement(By.tagName("h1"));
-        assertTrue(h1.getText().contains("mvc"));
+    public void testView1() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final DomElement h1 = page.getElementsByTagName("h1").get(0);
+        assertTrue(h1.getTextContent().contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
@@ -18,20 +18,18 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.eclipse.krazo.test.util.WebArchiveBuilder;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -50,11 +48,19 @@ public class ThymeleafIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "thymeleaf")
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.ext.thymeleaf")
             .addView(Paths.get(WEB_INF_SRC).resolve("views/hello.html").toFile(), "hello.html")
@@ -65,10 +71,10 @@ public class ThymeleafIT {
 
     @Test
     @RunAsClient
-    public void test() {
-        webDriver.get(baseURL + "resources/hello?user=mvc");
-        WebElement h1 = webDriver.findElement(By.tagName("h1"));
+    public void test() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello?user=mvc");
+        final DomElement h1 = page.getElementsByTagName("h1").get(0);
         assertNotNull(h1);
-        assertTrue(h1.getText().contains("mvc"));
+        assertTrue(h1.getTextContent().contains("mvc"));
     }
 }

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/VelocityIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/VelocityIT.java
@@ -18,17 +18,17 @@
  */
 package org.eclipse.krazo.test.ext;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -43,8 +43,16 @@ public class VelocityIT {
     @ArquillianResource
     private URL baseURL;
 
-    @Drone
-    private WebDriver webDriver;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+    }
 
     @Deployment(testable = false, name = "velocity")
     public static Archive createDeployment() {
@@ -58,16 +66,16 @@ public class VelocityIT {
     }
 
     @Test
-    public void testView1() {
-        webDriver.get(baseURL + "resources/hello/v1?user=mvc");
-        WebElement h1 = webDriver.findElement(By.tagName("h1"));
-        assertTrue(h1.getText().contains("mvc"));
+    public void testView1() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello/v1?user=mvc");
+        final DomElement h1 = page.getElementsByTagName("h1").get(0);
+        assertTrue(h1.getTextContent().contains("mvc"));
     }
-    
+
     @Test
-    public void testView2()  {
-        webDriver.get(baseURL + "resources/hello/v2?user2=mvc");
-        WebElement h1 = webDriver.findElement(By.tagName("h1"));
-        assertTrue(h1.getText().contains("mvc"));
+    public void testView2() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/hello/v2?user2=mvc");
+        final DomElement h1 = page.getElementsByTagName("h1").get(0);
+        assertTrue(h1.getTextContent().contains("mvc"));
     }
 }


### PR DESCRIPTION
see: #134

Because arquillian-drone relies on outdated versions of e.g. htmlunit, the tests use now
plain htmlunit and drone is removed

Signed-off-by: Erdle, Tobias <tobias.erdle@innoq.com>