### PR TITLE
Update version in master branch to 1.1.0-SNAPSHOT

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-core</artifactId>
     <name>Eclipse Krazo Core</name>

--- a/cxf/pom.xml
+++ b/cxf/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-cxf</artifactId>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-documentation</artifactId>

--- a/examples/application-path/pom.xml
+++ b/examples/application-path/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>application-path</artifactId>
     <packaging>war</packaging>

--- a/examples/book-cdi/pom.xml
+++ b/examples/book-cdi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>book-cdi</artifactId>
     <packaging>war</packaging>

--- a/examples/book-models/pom.xml
+++ b/examples/book-models/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>book-models</artifactId>
     <packaging>war</packaging>

--- a/examples/conversation/pom.xml
+++ b/examples/conversation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>conversation</artifactId>
     <packaging>war</packaging>

--- a/examples/csrf-property/pom.xml
+++ b/examples/csrf-property/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>csrf-property</artifactId>
     <packaging>war</packaging>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.krazo</groupId>
             <artifactId>krazo-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/def-ext/pom.xml
+++ b/examples/def-ext/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>def-ext</artifactId>
     <packaging>war</packaging>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.krazo</groupId>
             <artifactId>krazo-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/events/pom.xml
+++ b/examples/events/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>events</artifactId>
     <packaging>war</packaging>

--- a/examples/exceptions/pom.xml
+++ b/examples/exceptions/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>exceptions</artifactId>
     <packaging>war</packaging>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.krazo</groupId>
             <artifactId>krazo-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/facelets/pom.xml
+++ b/examples/facelets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>facelets</artifactId>
     <packaging>war</packaging>

--- a/examples/locale/pom.xml
+++ b/examples/locale/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>locale</artifactId>
     <packaging>war</packaging>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.krazo.examples</groupId>
     <artifactId>krazo-examples-parent</artifactId>

--- a/examples/produces/pom.xml
+++ b/examples/produces/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>produces</artifactId>
     <packaging>war</packaging>

--- a/examples/redirect/pom.xml
+++ b/examples/redirect/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>redirect</artifactId>
     <packaging>war</packaging>

--- a/examples/redirectScope/pom.xml
+++ b/examples/redirectScope/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>redirectScope</artifactId>
     <packaging>war</packaging>

--- a/examples/redirectScope2/pom.xml
+++ b/examples/redirectScope2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>redirectScope2</artifactId>
     <packaging>war</packaging>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.eclipse.krazo</groupId>
             <artifactId>krazo-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/examples/requestDispatcher/pom.xml
+++ b/examples/requestDispatcher/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>requestDispatcher</artifactId>
     <packaging>war</packaging>

--- a/examples/returns/pom.xml
+++ b/examples/returns/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>returns</artifactId>
     <packaging>war</packaging>

--- a/examples/uri-builder/pom.xml
+++ b/examples/uri-builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>uri-builder</artifactId>
     <packaging>war</packaging>

--- a/examples/validation-i18n/pom.xml
+++ b/examples/validation-i18n/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>validation-i18n</artifactId>
     <packaging>war</packaging>

--- a/examples/validation/pom.xml
+++ b/examples/validation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>validation</artifactId>
     <packaging>war</packaging>

--- a/examples/view-annotation/pom.xml
+++ b/examples/view-annotation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.examples</groupId>
         <artifactId>krazo-examples-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>view-annotation</artifactId>
     <packaging>war</packaging>

--- a/ext/asciidoc/pom.xml
+++ b/ext/asciidoc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-asciidoc</artifactId>
     <packaging>jar</packaging>

--- a/ext/freemarker/pom.xml
+++ b/ext/freemarker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-freemarker</artifactId>
     <packaging>jar</packaging>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-handlebars</artifactId>
     <packaging>jar</packaging>

--- a/ext/jade/pom.xml
+++ b/ext/jade/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-jade</artifactId>
     <packaging>jar</packaging>

--- a/ext/jetbrick/pom.xml
+++ b/ext/jetbrick/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.eclipse.krazo.ext</groupId>
     <artifactId>krazo-ext-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>krazo-jetbrick</artifactId>
   <packaging>jar</packaging>

--- a/ext/jsr223/pom.xml
+++ b/ext/jsr223/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-jsr223</artifactId>
     <packaging>jar</packaging>

--- a/ext/jtwig/pom.xml
+++ b/ext/jtwig/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-jtwig</artifactId>
     <packaging>jar</packaging>

--- a/ext/mustache/pom.xml
+++ b/ext/mustache/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-mustache</artifactId>
     <packaging>jar</packaging>

--- a/ext/pebble/pom.xml
+++ b/ext/pebble/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-pebble</artifactId>
     <packaging>jar</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.eclipse.krazo.ext</groupId>

--- a/ext/stringtemplate/pom.xml
+++ b/ext/stringtemplate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-stringtemplate</artifactId>
     <packaging>jar</packaging>

--- a/ext/thymeleaf/pom.xml
+++ b/ext/thymeleaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-thymeleaf</artifactId>
     <packaging>jar</packaging>

--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-velocity</artifactId>
     <packaging>jar</packaging>

--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-jersey</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.eclipse.krazo</groupId>
     <artifactId>krazo-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Eclipse Krazo Parent</name>
     <description>Eclipse Krazo Parent</description>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-resteasy</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-tck</artifactId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.krazo</groupId>
         <artifactId>krazo-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>krazo-testsuite</artifactId>


### PR DESCRIPTION
I'll start the release process for Eclipse Krazo 1.0.0 in a few days (just waiting for a final confirmation from the JCP). As we already finished the release paperwork (like release plan and the IP log), the release will be based on the `1.0.0-RC1` tag. So it makes sense to update the version in our master branch to the next release, which will be 1.1.0.

Please note that the pending 1.0.0 release shouldn't block further process. We can prepare our release plan for 1.1.0 and get it approved. In this case nothing is stopping us from releasing 1.1.0-M1 really soon. As most parts of the release process is automated and as we don't need any paperwork for milestone releases, I'm fine with pushing our milestones very often. :-)
