### PR TITLE
Updated API and TCK to 1.0.0

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -24,7 +24,7 @@ elif [ "${1}" == "glassfish-module" ]; then
   mvn -B -V -P\!bundled,module clean install
   cp core/target/krazo-core-*.jar ./glassfish5/glassfish/modules/
   cp jersey/target/krazo-jersey-*.jar ./glassfish5/glassfish/modules/
-  cp ~/.m2/repository/javax/mvc/javax.mvc-api/1.0.0-RC1/*.jar ./glassfish5/glassfish/modules/
+  cp ~/.m2/repository/javax/mvc/javax.mvc-api/1.0.0/*.jar ./glassfish5/glassfish/modules/
   find ./examples/ -name \*.war -exec cp {} ./glassfish5/glassfish/domains/domain1/autodeploy/ \;
   glassfish5/bin/asadmin start-domain
   sleep 120

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <spec.version>1.0.0-RC1</spec.version>
+        <spec.version>1.0.0</spec.version>
         <jersey.version>2.27</jersey.version>
         <javaee.version>8.0</javaee.version>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
 
-        <tck.version>1.0.0-RC1</tck.version>
+        <tck.version>1.0.0</tck.version>
 
         <!-- We don't deploy this module, because the TCK isn't in Maven Central yet -->
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
The 1.0.0 releases of the API and TCK are now available in Maven Central. So let's update our deps.

PS: I'll create the CQs later today.

PPS: I'll cherry-pick this commit to the Krazo 1.0.0 release branch after the merge.