### PR TITLE
Let tests autodiscover their resources

### DIFF
--- a/testsuite/src/main/java/org/eclipse/krazo/test/annotations/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/annotations/MyApplication.java
@@ -31,8 +31,4 @@ import javax.ws.rs.core.Application;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(AnnotationsController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/base/CsrfBaseApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/base/CsrfBaseApplication.java
@@ -35,13 +35,6 @@ import java.util.Set;
 public class CsrfBaseApplication extends Application {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        final Set<Class<?>> set = new HashSet<>();
-        set.add(CsrfBaseController.class);
-        return set;
-    }
-
-    @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> map = new HashMap<>();
         map.put(Csrf.CSRF_PROTECTION, Csrf.CsrfOptions.EXPLICIT);

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
@@ -25,11 +25,4 @@ import javax.ws.rs.core.Application;
 
 @ApplicationPath("resources")
 public class CsrfHiddenMethodApplication extends Application {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        final Set<Class<?>> set = new HashSet<>();
-        set.add(CsrfHiddenMethodController.class);
-        return set;
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/asciidoc/MyApplication.java
@@ -30,9 +30,4 @@ import java.util.Set;
  */
 @ApplicationPath("resources")
 public class MyApplication extends Application {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/freemarker/MyApplication.java
@@ -30,9 +30,4 @@ import java.util.Set;
  */
 @ApplicationPath("resources")
 public class MyApplication extends Application {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/handlebars/MyApplication.java
@@ -30,9 +30,4 @@ import java.util.Set;
  */
 @ApplicationPath("resources")
 public class MyApplication extends Application {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(PersonController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jade/JadeApplication.java
@@ -29,18 +29,10 @@ import java.util.Set;
 @ApplicationPath("/jade")
 public class JadeApplication extends Application {
 
-    private final Set<Class<?>> classes;
 
     public JadeApplication() {
-        classes = new HashSet<>();
-        classes.add(JadeController.class);
         // Register a filter to test if configuration via SystemProperties works
         String filterName = String.format("%s.%s", "org.eclipse.krazo.ext.jade.filter", "systemProperties");
         System.setProperty(filterName, DummyFilter.class.getName());
-    }
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        return classes;
     }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jetbrick/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/Jsr223Application.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jsr223/Jsr223Application.java
@@ -31,11 +31,4 @@ import java.util.Set;
 @ApplicationPath("mvc")
 public class Jsr223Application extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        HashSet<Class<?>> classes = new HashSet<>();
-        classes.add(NashornController.class);
-        classes.add(JythonController.class);
-        return classes;
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/jtwig/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/mustache/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/stringtemplate/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/thymeleaf/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/ext/velocity/MyApplication.java
@@ -31,8 +31,4 @@ import java.util.Set;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return Collections.singleton(HelloController.class);
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
@@ -8,10 +8,4 @@ import javax.ws.rs.core.Application;
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        final Set<Class<?>> set = new HashSet<>();
-        set.add(FormsController.class);
-        return set;
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mvc/MyApplication.java
@@ -21,9 +21,7 @@ package org.eclipse.krazo.test.mvc;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class MyApplication.
@@ -32,13 +30,6 @@ import java.util.Set;
  */
 @ApplicationPath("resources")
 public class MyApplication extends Application {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        final Set<Class<?>> set = new HashSet<>();
-        set.add(MvcController.class);
-        return set;
-    }
 
     @Override
     public Map<String, Object> getProperties() {


### PR DESCRIPTION
To be able to run the tests on any server without the problem of a
not initialized Krazo feature, they are all set to autodiscover their
resources now. This way, they behave like the TCK tests and we can
test specific behavior (like we have in Jersey or RESTEasy) in own tests

Signed-off-by: Erdle, Tobias <tobias.erdle@innoq.com>