### PR TITLE
Update handlebars to fix a security issue

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -26,17 +26,4 @@
         <cve>CVE-2015-9251</cve>
         <cve>CVE-2019-11358</cve>
     </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Most of the rendering in handlebars.java has been rewritten to Java. Only if the user wishes to write
-        util functions in javascript, those functions are executed using Nashorn and the original handlebars JS-source.
-
-        That does not mean this issue should not be fixed. We created an upsteam issue for it:
-        https://github.com/jknack/handlebars.java/issues/703
-       ]]></notes>
-        <packageUrl regex="true">pkg:javascript/handlebars\.js@4.0.4$</packageUrl>
-        <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control
-            the template
-        </vulnerabilityName>
-    </suppress>
 </suppressions>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
-            <version>4.1.2</version>
+            <version>4.2.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
... we found in #74. There was nothing we could do back then, so we had to whitelist it.

Upstream fix: https://github.com/jknack/handlebars.java/issues/703