### PR TITLE
Handlebars Block helper partials were being rendered on a single line

### DIFF
--- a/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/HandlebarsViewEngine.java
+++ b/ext/handlebars/src/main/java/org/eclipse/krazo/ext/handlebars/HandlebarsViewEngine.java
@@ -79,7 +79,7 @@ public class HandlebarsViewEngine extends ViewEngineBase {
             InputStreamReader in = new InputStreamReader(resourceAsStream, "UTF-8");
             BufferedReader bufferedReader = new BufferedReader(in);) {
 
-            String viewContent = bufferedReader.lines().collect(Collectors.joining());
+            String viewContent = bufferedReader.lines().collect(Collectors.joining("\n"));
 
             Template template = handlebars.compileInline(viewContent);
             template.apply(model, writer);


### PR DESCRIPTION
As the title suggests, Handlebars {{#block}} partials were all being rendered on a single line, which can obviously cause issues, especially if you have inline JavaScript with comments.

Signed-off-by: Jonathan Putney <jonathan@putney.io>