### PR TITLE
Added testsuite profile for Eclipse Glassfish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ jobs:
       env: TYPE=testsuite-liberty
       script: source .travis/install-liberty.sh && mvn -P${TYPE} -Dliberty.home=${LIBERTY_HOME} --projects testsuite clean verify ${BUILD_PROFILE}
     - stage: test
+      env: TYPE=testsuite-glassfish
+      before_script: .travis/start-glassfish.sh
+      script: mvn -P${TYPE} --projects testsuite clean verify ${BUILD_PROFILE}
+    - stage: test
       env: TYPE=tck-glassfish51-patched
       script: .travis/tests.sh ${TYPE}
     - stage: test

--- a/.travis/start-glassfish.sh
+++ b/.travis/start-glassfish.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl -L -s -o glassfish5.zip "http://download.eclipse.org/glassfish/web-5.1.0.zip"
+unzip glassfish5.zip
+glassfish5/bin/asadmin start-domain

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ The following sections describe how you test Eclipse Krazo against them. At the 
 - JDK 8
 - SNAPSHOTs are up to date in your local repository
 
+### Glassfish
+To run the Krazo testsuite with Eclipse Glassfish, you need to follow these steps:
+
+1. Download Eclipse Glassfish from the [official download page](https://projects.eclipse.org/projects/ee4j.glassfish/downloads) and unzip it.
+2. Start Eclipse Glassfish via `glassfish5/glassfish/bin/startserv`
+3. Go into the `testsuite` package of Eclipse Krazo and execute `mvn clean integration-test -Ptestsuite-glassfish`
+
 ### WildFly
 To run the Krazo testsuite with WildFly, you need to follow these steps:
 
@@ -38,6 +45,14 @@ openejb.system.apps = true
 ```
 3. Start TomEE with `sh catalina.sh jpda start`. This enables you to remote-debug the Arquillian tests.
 4. Go into the `testsuite` package of Eclipse Krazo and execute `mvn clean integration-test -Ptestsuite-tomee`
+
+### OpenLiberty
+To run the Krazo testsuite with OpenLiberty, you need to follow these steps. Please note that this process has been tested with 19.x only.
+
+1. Download OpenLiberty from the [official download page](https://openliberty.io/downloads/) and unzip it.
+2. Replace the file `wlp/templates/servers/defaultServer/server.xml` with `.travis/wlp-server-template.xml` from the Eclipse Krazo repository.
+3. Go into the `testsuite` package of Eclipse Krazo and execute `mvn clean integration-test -Ptestsuite-glassfish -Dliberty.home=c:/somewhere/wlp/`.
+   Please make sure to replace `c:/somewhere/wlp/` with the absolute path to the unpacked OpenLiberty distribution.
 
 ### Troubleshooting
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -271,6 +271,39 @@
             </build>
         </profile>
         <profile>
+            <id>testsuite-glassfish</id>
+            <properties>
+                <skipITs>false</skipITs>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.krazo</groupId>
+                    <artifactId>krazo-jersey</artifactId>
+                    <version>${project.version}</version>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-remote-3.1</artifactId>
+                    <version>1.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <arquillian.launch>glassfish</arquillian.launch>
+                                <testsuite.profile>testsuite-glassfish</testsuite.profile>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>testsuite-payara</id>
 
             <properties>

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -29,6 +29,13 @@
         <property name="browser">htmlunit</property>
     </extension>
 
+    <container qualifier="glassfish">
+        <configuration>
+            <property name="adminHost">localhost</property>
+            <property name="adminPort">4848</property>
+        </configuration>
+    </container>
+
     <container qualifier="wildfly" default="true">
         <configuration>
             <property name="username">admin</property>


### PR DESCRIPTION
This PR adds a new profile to our testsuite setup to run the tests against Eclipse Glassfish. Travis is green, so it should be fine. :-)

I also added a description about how to run the testsuite against OpenLiberty. But for some weird reason this doesn't work for me locally, although I documented exactly what the Travis scripts is doing. But maybe I'm missing something obvious.