### PR TITLE
Use Eclipse Nexus instead of Sonatype OSSRH for distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <description>Eclipse Krazo Parent</description>
     <url>https://projects.eclipse.org/projects/ee4j.krazo</url>
 
-     <parent>
+    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
@@ -95,17 +95,6 @@
             <timezone>CET</timezone>
         </developer>
     </developers>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <issueManagement>
         <system>GitHub</system>


### PR DESCRIPTION
Looks like we are not allowed anymore to push artifacts to Sonatype OSSRH:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=566865

The Eclipse Webmasters suggested trying the Eclipse Nexus instance. As we have to migrate to this one anyway in the long term, let's see if this fixes our current snapshot deployment issue.

Note: The Eclipse Nexus instance is defined in the EE4J parent, so we just have to remove our override.