### PR TITLE
Activate hidden method filtering by toggle

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
+++ b/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
@@ -102,4 +102,12 @@ public class KrazoConfig {
         return RedirectScopeManager.DEFAULT_QUERY_PARAM_NAME;
     }
 
+    public boolean isHiddenMethodFilterActive() {
+        final Object value = config.getProperty(Properties.HIDDEN_METHOD_FILTER_ACTIVE);
+        if (value instanceof Boolean) {
+            return (boolean) value;
+        }
+
+        return false;
+    }
 }

--- a/core/src/main/java/org/eclipse/krazo/Properties.java
+++ b/core/src/main/java/org/eclipse/krazo/Properties.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.krazo;
 
+import org.eclipse.krazo.forms.HiddenMethodFilter;
+
 /**
  * Interface Properties. Application-level properties used to configure Krazo.
  *
@@ -54,5 +56,9 @@ public interface Properties {
      * Property for defining default file extension for usage in views
      */
     String DEFAULT_VIEW_FILE_EXTENSION = "org.eclipse.krazo.defaultViewFileExtension";
-
+    
+    /**
+     * Boolean property which enables the {@link HiddenMethodFilter} when set to <code>true</code>.
+     */
+    String HIDDEN_METHOD_FILTER_ACTIVE = "org.eclipse.krazo.hiddenMethodFilterActive";
 }

--- a/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
@@ -31,6 +31,7 @@ import org.eclipse.krazo.engine.FaceletsViewEngine;
 import org.eclipse.krazo.engine.JspViewEngine;
 import org.eclipse.krazo.engine.ViewEngineFinder;
 import org.eclipse.krazo.event.*;
+import org.eclipse.krazo.forms.HiddenMethodFilter;
 import org.eclipse.krazo.jaxrs.JaxRsContextProducer;
 import org.eclipse.krazo.lifecycle.EventDispatcher;
 import org.eclipse.krazo.lifecycle.RequestLifecycle;
@@ -144,8 +145,10 @@ public class KrazoCdiExtension implements Extension {
 
                 // uri
                 ApplicationUris.class,
-                UriTemplateParser.class
+                UriTemplateParser.class,
 
+                // forms
+                HiddenMethodFilter.class
         );
     }
 

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
@@ -18,11 +18,21 @@
  */
 package org.eclipse.krazo.test.csrf.methods;
 
-import java.util.HashSet;
-import java.util.Set;
+import org.eclipse.krazo.Properties;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import java.util.HashMap;
+import java.util.Map;
 
 @ApplicationPath("resources")
 public class CsrfHiddenMethodApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put(Properties.HIDDEN_METHOD_FILTER_ACTIVE, true);
+
+        return props;
+    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
@@ -1,11 +1,20 @@
 package org.eclipse.krazo.test.forms;
 
-import java.util.HashSet;
-import java.util.Set;
+import org.eclipse.krazo.Properties;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import java.util.HashMap;
+import java.util.Map;
 
 @ApplicationPath("resources")
 public class MyApplication extends Application {
 
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put(Properties.HIDDEN_METHOD_FILTER_ACTIVE, true);
+
+        return props;
+    }
 }


### PR DESCRIPTION
At the moment, the HiddenMethodFilter is active all the time and checks every
request for possibly changed methods. I could imagine that this is not
wanted by every user, because they maybe want to use other mechanisms to
determine the HTTP method or just use the HTML Form standards. To ensure
that this feature doesn't cause trouble to anyone who isn't aware of the feature,
now a toggle is added to the KrazoProperties and the filter can be activated in the JAX-RS
application.

Signed-off-by: Tobias Erdle <tobias.erdle@innoq.com>