### PR TITLE
Fix tests after namespace switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ jobs:
   include:
     - stage: build
       script: mvn -B -V clean install ${BUILD_PROFILE}
-#    - stage: test
-#      script: mvn -B -V test ${BUILD_PROFILE}
+    - stage: test
+      script: mvn -B -V test ${BUILD_PROFILE}
 #    - stage: test
 #      env: TYPE=glassfish-module
 #      script: .travis/tests.sh ${TYPE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install: /bin/true
 jobs:
   include:
     - stage: build
-      script: mvn -B -V -DskipTests clean install ${BUILD_PROFILE}
+      script: mvn -B -V clean install ${BUILD_PROFILE}
 #    - stage: test
 #      script: mvn -B -V test ${BUILD_PROFILE}
 #    - stage: test

--- a/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
+++ b/core/src/main/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverter.java
@@ -43,7 +43,7 @@ public class BigDecimalConverter extends NumberConverter<BigDecimal> {
 
             return ConverterResult.success(
                     parseNumber(value, locale)
-                            .map(val -> new BigDecimal(val.toString()))
+                            .map(val -> val.equals(Double.NaN) ? null : new BigDecimal(val.toString()))
                             .orElse(null)
             );
 

--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/BigDecimalConverterTest.java
@@ -48,7 +48,7 @@ public class BigDecimalConverterTest {
                 new Object[]{"-2", BigDecimal.valueOf(-2), false},
                 new Object[]{"3E2", new BigDecimal("300"), false},
                 new Object[]{"", null, false},
-                new Object[]{"NaN", null, true},
+                new Object[]{"NaN", null, false},
                 new Object[]{"asd", null, true},
                 new Object[]{null, null, false}
             );

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
@@ -123,19 +123,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.2.0</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.2.0</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.1</version>
                 </plugin>
 
                 <plugin>
@@ -156,13 +156,13 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.0.3</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.2</version>
                 </plugin>
 
                 <plugin>
@@ -174,13 +174,13 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>5.1.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.2.3</version>
                     <inherited>true</inherited>
                     <configuration>
                         <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -235,15 +235,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>jdk9plus</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
-        </profile>
         <profile>
             <id>release</id>
             <activation>


### PR DESCRIPTION
Not sure why thee BigDecimal conversion test failed after the switch.
Could be Double.NaN is treated differently in Java 8 and 11?
Actually not sure why it worked before either as it looks more correct now :)
Thiis commit is the interesting one: https://github.com/eclipse-ee4j/krazo/pull/215/commits/97dc817f7e114ec0dafe5d30565c879de6e847d5
(The other is just some plugin updates)