### PR TITLE
use jcp namespace in xml examples in quickstart

### DIFF
--- a/documentation/src/main/asciidoc/_quickstart.adoc
+++ b/documentation/src/main/asciidoc/_quickstart.adoc
@@ -309,9 +309,9 @@ The file to create is called `web.xml` and should be placed in the `src/main/web
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://java.sun.com/xml/ns/javaee"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_4_0.xsd"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
 
   <listener>


### PR DESCRIPTION
I noticed one of our web.xml examples in the documentation still uses the old "java.sun.com" namespace. We should replace that with the JCP-NS.