### PR TITLE
New TCK runner profile for Glassfish with Krazo module

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -133,6 +133,41 @@
                                 <arquillian.launch>glassfish</arquillian.launch>
                                 <jakarta.mvc.tck.api.BaseArchiveProvider>
                                     org.eclipse.krazo.tck.glassfish.GlassfishArchiveProvider
+                                </jakarta.mvc.tck.api.BaseArchiveProvider>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-glassfish-remote-3.1</artifactId>
+                    <version>1.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Run TCK against Glassfish 6 with Krazo installed as a Glassfish module -->
+        <profile>
+            <id>tck-glassfish-module</id>
+            <activation>
+                <property>
+                    <name>tck-env</name>
+                    <value>glassfish-module</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <dependenciesToScan>jakarta.mvc.tck:mvc-tck-tests</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <arquillian.launch>glassfish</arquillian.launch>
+                                <jakarta.mvc.tck.api.BaseArchiveProvider>
+                                    org.eclipse.krazo.tck.glassfish.GlassfishModuleArchiveProvider
                                 </jakarta.mvc.tck.api.BaseArchiveProvider>
                             </systemPropertyVariables>
                         </configuration>

--- a/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishModuleArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/krazo/tck/glassfish/GlassfishModuleArchiveProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.tck.glassfish;
+
+import org.eclipse.krazo.tck.AbstractArchiveProvider;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * BaseArchiveProvider implementation for running TCK against Glassfish with Krazo installed as a Glassfish module
+ */
+public class GlassfishModuleArchiveProvider extends AbstractArchiveProvider {
+
+    @Override
+    public WebArchive getBaseArchive() {
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+}


### PR DESCRIPTION
A first version of a Maven profile to run the TCK against Glassfish with Krazo installed as a Glassfish module.

However, the TCK currently fails horribly. It looks like HK2 isn't able to do any CDI injections into our JAX-RS providers (like `ViewableWriter`). Also, I'm not seeing any logs which indicate that Krazo is bootstrapped correctly at all.

For a quick test, I added a `beans.xml` to `krazo-core` with discovery mode `all`. In this case it seems to work better, but Glassfish reports that our `ServletContainerInitializer` implementation cannot be loaded. So it looks like Glassfish finds our ServiceLoader file, but fails to load our implementation.

All of this is really weird. And IIRC it worked much better with Glassfish 5 back then.

Here a few tips on how to do similar experiments. Maybe somebody finds some time to have a look as well.

```sh
# Build Krazo
cd ${KRAZO_REPO}
mvn -Pstaging -DskipTests clean install 

# Copy Krazo JARs + the spec JAR to the Glassfish module directory:
cp core/target/krazo-core-*.jar ${GLASSFISH_HOME}/glassfish/modules/
cp jersey/target/krazo-jersey-*.jar ${GLASSFISH_HOME}/glassfish/modules/
mvn dependency:copy -Dartifact=jakarta.mvc:jakarta.mvc-api:2.0.0 -DoutputDirectory=${GLASSFISH_HOME}/glassfish/modules/

# Start Glassfish
cd ${GLASSFISH_HOME}
./glassfish/bin/startserv

# Run the TCK
cd ${KRAZO_REPO}/tck
mvn -Pstaging -Dtck-env=glassfish-module verify
```

However, IMO this PR can be already merged.