### PR TITLE
Allow to use Krazo as a Glassfish module

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/bootstrap/Initializer.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/Initializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public final class Initializer {
         Set<Class<?>> controllersFound = servletContext != null
                 ? (Set<Class<?>>) servletContext.getAttribute(KrazoContainerInitializer.CONTROLLER_CLASSES)
                 : null;
-        boolean enable = controllersFound == null || !controllersFound.isEmpty();
+        boolean enable = controllersFound != null && !controllersFound.isEmpty();
 
         log.log(Level.FINE, "Is Eclipse Krazo application detected: {0}", enable);
         return enable;

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,27 +89,33 @@ public class JaxRsContextProducer {
         return Objects.requireNonNull(resourceInfo, "Cannot produce ResourceInfo");
     }
 
-    void setConfiguration(Configuration configuration) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setConfiguration(Configuration configuration) {
         this.configuration = Objects.requireNonNull(configuration, "Configuration must not be null");
     }
 
-    void setRequest(HttpServletRequest request) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setRequest(HttpServletRequest request) {
         this.request = Objects.requireNonNull(request, "Request must not be null");
     }
 
-    void setResponse(HttpServletResponse response) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setResponse(HttpServletResponse response) {
         this.response = Objects.requireNonNull(response, "Response must not be null");
     }
 
-    void setApplication(Application application) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setApplication(Application application) {
         this.application = Objects.requireNonNull(application, "Application must not be null");
     }
 
-    void setUriInfo(UriInfo uriInfo) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setUriInfo(UriInfo uriInfo) {
         this.uriInfo = Objects.requireNonNull(uriInfo, "UriInfo must not be null");
     }
 
-    void setResourceInfo(ResourceInfo resourceInfo) {
+    // using 'package private' here seems to break the CDI scope for some reason
+    protected void setResourceInfo(ResourceInfo resourceInfo) {
         this.resourceInfo = Objects.requireNonNull(resourceInfo, "ResourceInfo must not be null");
     }
 


### PR DESCRIPTION
This PR contains two fixes which broke Krazo when installed as a Glassfish module. With these fixes Krazo now passes the TCK against Glassfish 6.1.0-M1 with Krazo installed in the `glassfish/modules` folder on JDK11. :tada: 

The two fixes are:

- Back then we created a mechanism for Krazo to detect if the "current application" contains MVC controllers and only bootstrap itself if controllers were found. However, this didn't work in CXF for some reason. Therefore, we added a fallback so that if discovery of controllers doesn't work, Krazo initializes nevertheless. When installed as a Glassfish module, this lead to the situation that Krazo was initialized even for internal Glassfish applications like the admin console which was causing followup errors. As CXF isn't or priority anymore, Krazo will now only initialize if the discovery mechanism works correctly and finds at least one controller.
- The other issue was that for some reason calling a package private method on a request-scoped CDI bean hit a different instance of that bean than calling a `public` or `protected` method. This could be caused by some CDI proxy issue. Not completely sure to be honest, but it took me some hours of debugging to find the cause. :disappointed:  However, using `protected` methods instead works fine, so I adjusted that code accordingly.

I'll create a corresponding Jenkins job for running the TCK against Glassfish + Krazo module after this PR is merged!