### PR TITLE
Load JaxRsContextProducer via BeanManager again

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
@@ -17,6 +17,8 @@
  */
 package org.eclipse.krazo.jaxrs;
 
+import org.eclipse.krazo.util.CdiUtils;
+
 import jakarta.annotation.Priority;
 import jakarta.mvc.Controller;
 import jakarta.servlet.http.HttpServletRequest;
@@ -56,11 +58,10 @@ public class PostMatchingRequestFilter implements ContainerRequestFilter {
     @Context
     private ResourceInfo resourceInfo;
 
-    @Context
-    private JaxRsContextProducer contextProducer;
-
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        final JaxRsContextProducer contextProducer = CdiUtils.getApplicationBean(JaxRsContextProducer.class)
+                .orElseThrow(() -> new IllegalStateException("Cannot find CDI managed JaxRsContextProducer"));
 
         // store JAX-RS context objects so we can produce them via CDI
         contextProducer.setConfiguration(configuration);
@@ -69,7 +70,5 @@ public class PostMatchingRequestFilter implements ContainerRequestFilter {
         contextProducer.setApplication(application);
         contextProducer.setUriInfo(uriInfo);
         contextProducer.setResourceInfo(resourceInfo);
-
     }
-
 }

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
@@ -30,7 +30,6 @@ import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
-import java.io.IOException;
 
 /**
  * Pre-Matching ContainerRequestFilter
@@ -56,11 +55,10 @@ public class PreMatchingRequestFilter implements ContainerRequestFilter {
     @Context
     private UriInfo uriInfo;
 
-    @Context
-    private JaxRsContextProducer contextProducer;
-
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        final JaxRsContextProducer contextProducer = CdiUtils.getApplicationBean(JaxRsContextProducer.class)
+                .orElseThrow(() -> new IllegalStateException("Cannot find CDI managed JaxRsContextProducer"));
 
         // store JAX-RS context objects so we can produce them via CDI
         contextProducer.setConfiguration(configuration);


### PR DESCRIPTION
It seems, that the @Context annotation has problems with injecting our
JaxRsContextProducer also on RESTEasy. Unfortunately, the documentation
of @Context itself isn't very helpful, so I just reverted the change and
load the Producer manually again.

see: #250