### PR TITLE
Fixed dependency scopes and versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -117,50 +117,39 @@
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
             <version>${spec.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
             <version>3.0.0</version>
-<!--            <type>bundle</type>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>5.0.0</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>3.0.0</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>3.0.0</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>2.0.0</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
 
-        <!-- TODO remove -->
-<!--        <dependency>-->
-<!--            <groupId>jakarta.el</groupId>-->
-<!--            <artifactId>jakarta.el-api</artifactId>-->
-<!--            <version>4.0.0-RC2</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>jakarta.interceptor</groupId>-->
-<!--            <artifactId>jakarta.interceptor-api</artifactId>-->
-<!--            <version>2.0.0-RC2</version>-->
-<!--        </dependency>-->
         <!-- Test scope -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.0</version>
+            <version>9.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -79,7 +79,19 @@
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
             <version>${spec.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Krazo Core -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>8.0.0</version>
+            <version>9.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I'm working on preparing a release branch for the upcoming 2.0.1 release and found some issues with our dependencies.

  * Most of the Jakarta EE API dependencies in the `core` module are `compile` instead of `provided`-scoped. I guess this was done by mistake during the namespace migration.
  * The `testsuite` and the `ext` modules are still using the Jakarta EE 8 API (`javax.*` version). I guess this didn't cause any problems, because we pull in the individual spec JARs in the correct version as well via some transitive path.
  * The `core` module has a `compile`-scoped dependency on the MVC API. We did this intentionally back then, but I guess it is time to change this and use `provided` scope as for all other APIs.

I ran the TCK for Glassfish and Wildfly locally and everything works fine.

Please note that I'll prepare a separate pull request in the next days to add a `<dependencyManagement>` section to the parent pom to unify the overall dependency handling which is quite confusing at the moment. But I want to get a quick fix in ASAP so we can cherry-pick it into the 2.0.1 release branch.