### PR TITLE
Removed duplicated dependencyManagement entry

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -83,10 +83,6 @@
 
             <!-- Used by archive provider to lookup versions -->
             <dependency>
-                <groupId>jakarta.mvc</groupId>
-                <artifactId>jakarta.mvc-api</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>org.eclipse.krazo</groupId>
                 <artifactId>krazo-core</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
It looks like the changes introduced in #263 broke the TCK module, as there are now two `dependencyManagement` entries for the MVC API (one in the parent and one in the `tck` module itself). For some reason, ShrinkWrap isn't able to resolve the correct version in this case.

```
[INFO] Running jakarta.mvc.tck.tests.mvc.redirect.scope.RedirectScopeTest
org.jboss.shrinkwrap.resolver.api.ResolutionException: Unable to get version for dependency specified by jakarta.mvc:jakarta.mvc-api:compile, it was not provided in neither <dependencyManagement> nor <dependencies> sections.
	at org.jboss.shrinkwrap.resolver.impl.maven.task.ResolveVersionFromMetadataTask.execute(ResolveVersionFromMetadataTask.java:124)
	at org.jboss.shrinkwrap.resolver.impl.maven.PomEquippedResolveStageBaseImpl.resolveVersion(PomEquippedResolveStageBaseImpl.java:85)
	at org.jboss.shrinkwrap.resolver.impl.maven.ResolveStageBaseImpl.resolveDependency(ResolveStageBaseImpl.java:190)
	at org.jboss.shrinkwrap.resolver.impl.maven.ResolveStageBaseImpl.resolveDependency(ResolveStageBaseImpl.java:185)
	at org.jboss.shrinkwrap.resolver.impl.maven.ResolveStageBaseImpl.resolve(ResolveStageBaseImpl.java:79)
	at org.jboss.shrinkwrap.resolver.impl.maven.ResolveStageBaseImpl.resolve(ResolveStageBaseImpl.java:44)
	at org.eclipse.krazo.tck.AbstractArchiveProvider.resolveMvcSpecJar(AbstractArchiveProvider.java:61)
	at org.eclipse.krazo.tck.wildfly.WildflyArchiveProvider.getBaseArchive(WildflyArchiveProvider.java:32)
	at jakarta.mvc.tck.util.Archives.createBaseWebArchiveFromProvider(Archives.java:57)
	at jakarta.mvc.tck.util.Archives.getBaseArchive(Archives.java:27)
	at jakarta.mvc.tck.util.Archives.getMvcArchive(Archives.java:35)
	at jakarta.mvc.tck.util.Archives.getMvcArchive(Archives.java:31)
```

This PR fixes the issue.