### PR TITLE
Update shrinkwrap-resolver-bom to latest version

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -18,8 +18,8 @@
     SPDX-License-Identifier: Apache-2.0
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>3.1.3</version>
+                <version>3.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This is needed for #274 to be able to use the latest version of `jinjava`. 

The reason for this is that the latest `jinjava` version depends on `guava` version `25.0-jre` and uses the method `com.google.common.collect.ImmutableMap.toImmutableMap` which is not present in the `guava` version imported by `shrinkwrap-resolver-bom` version `3.1.3`.
`shrinkwrap-resolver-bom` version `3.1.4` does not depend on `guava` anymore, so it should resolve the issue.