### PR TITLE
Open java.security and java.io for tests

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -258,6 +258,10 @@
                             <excludedGroups>
                                 org.eclipse.krazo.test.helper.annotation.IgnoreOnWildfly
                             </excludedGroups>
+                            <argLine>
+                                --add-opens=java.base/java.security=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                            </argLine>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
JDK 17 brought the strong encapsulated modules, which prevents our tests from accessing some JDK APIs during runtime via reflection.
By opening them in the failsafe plugin, we're able to run the tests again. On server side, this settings are done within the standalone.sh per default.

fixes: #278