### PR TITLE
Replace test running inside container with remote variant

### DIFF
--- a/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterApplication.java
@@ -1,0 +1,8 @@
+package org.eclipse.krazo.test.convert.available;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("resources")
+public class AvailableConverterApplication extends Application {
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterController.java
@@ -1,0 +1,43 @@
+package org.eclipse.krazo.test.convert.available;
+
+import java.lang.annotation.Annotation;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.eclipse.krazo.binding.convert.ConverterRegistry;
+
+import jakarta.inject.Inject;
+import jakarta.mvc.Controller;
+import jakarta.mvc.Models;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Controller
+@Path("available-converter")
+public class AvailableConverterController{
+
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[]{};
+    
+    @Inject
+    private ConverterRegistry converterRegistry;
+
+    @Inject
+    private Models models;
+
+    @GET
+    public String doGetIndex() {
+        models.put("short", containsMvcConverterForType(Short.class));
+        models.put("long", containsMvcConverterForType(Long.class));
+        models.put("integer", containsMvcConverterForType(Integer.class));
+        models.put("float", containsMvcConverterForType(Float.class));
+        models.put("double", containsMvcConverterForType(Double.class));
+        models.put("biginteger", containsMvcConverterForType(BigInteger.class));
+        models.put("bigdecimal", containsMvcConverterForType(BigDecimal.class));
+
+        return "index.jsp";
+    }
+
+    private boolean containsMvcConverterForType(Class<?> clazz) {
+        return converterRegistry.lookup(clazz, EMPTY_ANNOTATIONS) != null;
+    }
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterController.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/convert/available/AvailableConverterController.java
@@ -26,13 +26,13 @@ public class AvailableConverterController{
 
     @GET
     public String doGetIndex() {
-        models.put("short", containsMvcConverterForType(Short.class));
-        models.put("long", containsMvcConverterForType(Long.class));
-        models.put("integer", containsMvcConverterForType(Integer.class));
-        models.put("float", containsMvcConverterForType(Float.class));
-        models.put("double", containsMvcConverterForType(Double.class));
-        models.put("biginteger", containsMvcConverterForType(BigInteger.class));
-        models.put("bigdecimal", containsMvcConverterForType(BigDecimal.class));
+        models.put("short_conv", containsMvcConverterForType(Short.class));
+        models.put("long_conv", containsMvcConverterForType(Long.class));
+        models.put("integer_conv", containsMvcConverterForType(Integer.class));
+        models.put("float_conv", containsMvcConverterForType(Float.class));
+        models.put("double_conv", containsMvcConverterForType(Double.class));
+        models.put("biginteger_conv", containsMvcConverterForType(BigInteger.class));
+        models.put("bigdecimal_conv", containsMvcConverterForType(BigDecimal.class));
 
         return "index.jsp";
     }

--- a/testsuite/src/main/resources/convert/available/views/index.jsp
+++ b/testsuite/src/main/resources/convert/available/views/index.jsp
@@ -1,0 +1,18 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!doctype html>
+<html>
+<head>
+    <title>Available converter test</title>
+</head>
+<body>
+    <h1>Available converter test</h1>
+
+    <div id="short">${short}</div>
+    <div id="long">${long}</div>
+    <div id="integer">${integer}</div>
+    <div id="float">${float}</div>
+    <div id="double">${double}</div>
+    <div id="biginteger">${biginteger}</div>
+    <div id="bigdecimal">${bigdecimal}</div>
+</body>
+</html>

--- a/testsuite/src/main/resources/convert/available/views/index.jsp
+++ b/testsuite/src/main/resources/convert/available/views/index.jsp
@@ -7,12 +7,12 @@
 <body>
     <h1>Available converter test</h1>
 
-    <div id="short">${short}</div>
-    <div id="long">${long}</div>
-    <div id="integer">${integer}</div>
-    <div id="float">${float}</div>
-    <div id="double">${double}</div>
-    <div id="biginteger">${biginteger}</div>
-    <div id="bigdecimal">${bigdecimal}</div>
+    <div id="short_conv">${short_conv}</div>
+    <div id="long_conv">${long_conv}</div>
+    <div id="integer_conv">${integer_conv}</div>
+    <div id="float_conv">${float_conv}</div>
+    <div id="double_conv">${double_conv}</div>
+    <div id="biginteger_conv">${biginteger_conv}</div>
+    <div id="bigdecimal_conv">${bigdecimal_conv}</div>
 </body>
 </html>

--- a/testsuite/src/test/java/org/eclipse/krazo/test/convert/AvailableConvertersIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/convert/AvailableConvertersIT.java
@@ -56,49 +56,49 @@ public class AvailableConvertersIT {
     public void shortConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("short").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("short_conv").getTextContent()));
     }
 
     @Test
     public void longConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("long").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("long_conv").getTextContent()));
     }
 
     @Test
     public void integerConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("integer").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("integer_conv").getTextContent()));
     }
 
     @Test
     public void floatConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("float").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("float_conv").getTextContent()));
     }
 
     @Test
     public void doubleConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("double").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("double_conv").getTextContent()));
     }
 
     @Test
     public void bigIntegerConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("biginteger").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("biginteger_conv").getTextContent()));
     }
 
     @Test
     public void bigDecimalConverterRegistered() throws Exception {
         final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("bigdecimal").getTextContent()));
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("bigdecimal_conv").getTextContent()));
     }
 
     private static String formatErrorMessage(final Class<?> clazz) {

--- a/testsuite/src/test/java/org/eclipse/krazo/test/convert/AvailableConvertersIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/convert/AvailableConvertersIT.java
@@ -1,83 +1,104 @@
 package org.eclipse.krazo.test.convert;
 
-import org.eclipse.krazo.binding.convert.ConverterRegistry;
-import org.eclipse.krazo.binding.convert.MvcConverter;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.nio.file.Paths;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
 import org.eclipse.krazo.test.util.WebArchiveBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import jakarta.inject.Inject;
-import java.lang.annotation.Annotation;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
 public class AvailableConvertersIT {
 
-    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[]{};
+    private static final String RESOURCES = "src/main/resources/convert/available";
+    private static final String HTTP_RESOURCE = "resources/available-converter";
 
-    @Deployment(name = "available-converters")
+    @Deployment(testable = false, name = "available-converter")
     public static WebArchive createDeployment() {
         return new WebArchiveBuilder()
+            .addPackage("org.eclipse.krazo.test.convert.available")
+            .addView(Paths.get(RESOURCES)
+                         .resolve("views/index.jsp")
+                         .toFile(), "index.jsp")
             .addBeansXml()
             .build();
     }
 
-    @Inject
-    private ConverterRegistry converterRegistry;
+    @ArquillianResource
+    private URL baseURL;
 
-    @Test
-    public void shortConverterRegistered() {
-        final MvcConverter<Short> converter = converterRegistry.lookup(Short.class, EMPTY_ANNOTATIONS);
+    private WebClient webClient;
 
-        assertNotNull(formatErrorMessage(Short.class), converter);
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setRedirectEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        webClient.close();
     }
 
     @Test
-    public void longConverterRegistered() {
-        final MvcConverter<Long> converter = converterRegistry.lookup(Long.class, EMPTY_ANNOTATIONS);
+    public void shortConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(Long.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("short").getTextContent()));
     }
 
     @Test
-    public void integerConverterRegistered() {
-        final MvcConverter<Integer> converter = converterRegistry.lookup(Integer.class, EMPTY_ANNOTATIONS);
+    public void longConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(Integer.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("long").getTextContent()));
     }
 
     @Test
-    public void floatConverterRegistered() {
-        final MvcConverter<Float> converter = converterRegistry.lookup(Float.class, EMPTY_ANNOTATIONS);
+    public void integerConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(Float.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("integer").getTextContent()));
     }
 
     @Test
-    public void doubleConverterRegistered() {
-        final MvcConverter<Double> converter = converterRegistry.lookup(Double.class, EMPTY_ANNOTATIONS);
+    public void floatConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(Double.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("float").getTextContent()));
     }
 
     @Test
-    public void bigIntegerConverterRegistered() {
-        final MvcConverter<BigInteger> converter = converterRegistry.lookup(BigInteger.class, EMPTY_ANNOTATIONS);
+    public void doubleConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(BigInteger.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("double").getTextContent()));
     }
 
     @Test
-    public void bigDecimalConverterRegistered() {
-        final MvcConverter<BigDecimal> converter = converterRegistry.lookup(BigDecimal.class, EMPTY_ANNOTATIONS);
+    public void bigIntegerConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
 
-        assertNotNull(formatErrorMessage(BigDecimal.class), converter);
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("biginteger").getTextContent()));
+    }
+
+    @Test
+    public void bigDecimalConverterRegistered() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + HTTP_RESOURCE);
+
+        assertTrue(formatErrorMessage(Short.class), Boolean.valueOf(page.getElementById("bigdecimal").getTextContent()));
     }
 
     private static String formatErrorMessage(final Class<?> clazz) {


### PR DESCRIPTION
As it seems that the test was flaky because of the namespace change from
javax -> jakarta and a update of Arquillian and HTMLUnit didn't help, I
decided to replace the test with a similar one which runs outside the
container. This fixes the build errors on Glassfish and gives us the
same information.

fixes: #276