### PR TITLE
Fixed Maven warnings for deprecated org.junit.Assert.assertThat(...)

### DIFF
--- a/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/binding/convert/impl/SupportsTest.java
@@ -36,13 +36,13 @@ public abstract class SupportsTest<T> {
 
     protected static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[]{};
 
-    private MvcConverter<T> mvcConverter;
+    private final MvcConverter<T> mvcConverter;
 
     SupportsTest(MvcConverter<T> mvcConverter) {
         this.mvcConverter = mvcConverter;
     }
 
-    @Parameter(0)
+    @Parameter()
     public Class clazz;
     @Parameter(1)
     public Annotation[] annotations;
@@ -50,6 +50,7 @@ public abstract class SupportsTest<T> {
     public boolean isSupported;
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testSupports() {
        if (isSupported) {
            assertTrue(mvcConverter.supports(clazz, annotations));

--- a/core/src/test/java/org/eclipse/krazo/engine/ViewEngineBaseTest.java
+++ b/core/src/test/java/org/eclipse/krazo/engine/ViewEngineBaseTest.java
@@ -23,15 +23,13 @@ import org.junit.Test;
 
 import jakarta.mvc.engine.ViewEngine;
 import jakarta.mvc.engine.ViewEngineContext;
-import jakarta.mvc.engine.ViewEngineException;
 import jakarta.ws.rs.core.Configuration;
 
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * The JUnit test for the ViewEngineBase class.
@@ -46,7 +44,7 @@ public class ViewEngineBaseTest {
 			return false;
 		}
 		@Override
-		public void processView(ViewEngineContext context) throws ViewEngineException {
+		public void processView(ViewEngineContext context) {
 
 		}
 	};
@@ -60,8 +58,8 @@ public class ViewEngineBaseTest {
 		expect(ctx.getView()).andReturn("index.jsp");
 		expect(ctx.getView()).andReturn("/somewhere/else/index.jsp");
 		replay(ctx, config);
-		assertThat(viewEngineBase.resolveView(ctx), is("/WEB-INF/views/index.jsp"));
-		assertThat(viewEngineBase.resolveView(ctx), is("/somewhere/else/index.jsp"));
+		assertEquals("/WEB-INF/views/index.jsp", viewEngineBase.resolveView(ctx));
+		assertEquals("/somewhere/else/index.jsp", viewEngineBase.resolveView(ctx));
 		verify(ctx, config);
 	}
 
@@ -73,7 +71,7 @@ public class ViewEngineBaseTest {
 		expect(ctx.getConfiguration()).andReturn(config);
 		expect(ctx.getView()).andReturn("index.jsp");
 		replay(ctx, config);
-		assertThat(viewEngineBase.resolveView(ctx), is("/somewhere/else/index.jsp"));
+		assertEquals("/somewhere/else/index.jsp", viewEngineBase.resolveView(ctx));
 		verify(ctx, config);
 	}
 

--- a/core/src/test/java/org/eclipse/krazo/uri/ApplicationUrisTest.java
+++ b/core/src/test/java/org/eclipse/krazo/uri/ApplicationUrisTest.java
@@ -24,9 +24,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * <p>The test for {@link ApplicationUris}.</p>
@@ -39,7 +37,7 @@ public class ApplicationUrisTest {
 
     private static final String PATH = "/foo";
 
-    private static UriTemplate TEMPLATE = UriTemplate.fromTemplate(PATH).build();
+    private static final UriTemplate TEMPLATE = UriTemplate.fromTemplate(PATH).build();
 
     @Before
     public void onBefore() {
@@ -55,15 +53,15 @@ public class ApplicationUrisTest {
         params.put("c", "e");
         params.put("m", 1);
         params.put("q", 2);
-        assertThat(uris.get("SomeController#root", params).toString(), equalTo("/a/d/e;m=1?q=2"));
+        assertEquals("/a/d/e;m=1?q=2", uris.get("SomeController#root", params).toString());
     }
 
     @Test
     public void shouldRegisterByNameAndRef() throws NoSuchMethodException {
         uris.register(TEMPLATE, UriBuilderTestControllers.UriRefController.class.getMethod("getRoot"));
-        assertThat(uris.get("uri-ref").toString(), equalTo(PATH));
-        assertThat(uris.get("UriRefController#getRoot").toString(), equalTo(PATH));
-        assertThat(uris.list().size(), is(2));
+        assertEquals(PATH, uris.get("uri-ref").toString());
+        assertEquals(PATH, uris.get("UriRefController#getRoot").toString());
+        assertEquals(2, uris.list().size());
     }
 
     @Test

--- a/core/src/test/java/org/eclipse/krazo/uri/UriTemplateParserTest.java
+++ b/core/src/test/java/org/eclipse/krazo/uri/UriTemplateParserTest.java
@@ -29,9 +29,7 @@ import java.util.HashSet;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * <p>The test for {@link UriTemplateParser}.</p>
@@ -57,51 +55,51 @@ public class UriTemplateParserTest {
     public void shouldInitApplicationUris() {
         HashSet<Class<?>> controllers = new HashSet<>(Arrays.asList(UriBuilderTestControllers.SomeController.class, UriBuilderTestControllers.ParamsController.class));
         ApplicationUris uris = uriTemplateParser.init(controllers);
-        assertThat(uris.list().size(), is(7));
+        assertEquals(7, uris.list().size());
     }
 
     @Test
     public void shouldParseMethods() throws NoSuchMethodException {
-        assertThat(uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("root"), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/some").build()));
-        assertThat(uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("path"), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/some/path").build()));
+        assertEquals(UriTemplate.fromTemplate("/base-path/some").build(),
+            uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("root"), BASE_PATH));
+        assertEquals(UriTemplate.fromTemplate("/base-path/some/path").build(),
+            uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("path"), BASE_PATH));
     }
 
     @Test
     public void shouldParseFromInheritedMethods() throws NoSuchMethodException {
-        assertThat(uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("parent"), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/some/parent").build()));
-        assertThat(uriTemplateParser.parseMethod(UriBuilderTestControllers.ControllerImplementation.class.getMethod("show"), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/implementation/show").build()));
+        assertEquals(UriTemplate.fromTemplate("/base-path/some/parent").build(),
+            uriTemplateParser.parseMethod(UriBuilderTestControllers.SomeController.class.getMethod("parent"), BASE_PATH));
+        assertEquals(UriTemplate.fromTemplate("/base-path/implementation/show").build(),
+            uriTemplateParser.parseMethod(UriBuilderTestControllers.ControllerImplementation.class.getMethod("show"), BASE_PATH));
     }
 
     @Test
     public void shouldParseMethodParams() throws NoSuchMethodException {
-        assertThat(uriTemplateParser.parseMethod(
-            UriBuilderTestControllers.ParamsController.class.getMethod("pathParams", String.class, long.class), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/params/path/{p1}/{p2}").build()));
-        assertThat(uriTemplateParser.parseMethod(
-            UriBuilderTestControllers.ParamsController.class.getMethod("queryParams", String.class, long.class), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/params/query").queryParam("q1").queryParam("q2").build()));
-        assertThat(uriTemplateParser.parseMethod(
-            UriBuilderTestControllers.ParamsController.class.getMethod("matrixParams", String.class, long.class), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/params/matrix").matrixParam("m1").matrixParam("m2").build()));
+        assertEquals(UriTemplate.fromTemplate("/base-path/params/path/{p1}/{p2}").build(),
+            uriTemplateParser.parseMethod(
+            UriBuilderTestControllers.ParamsController.class.getMethod("pathParams", String.class, long.class), BASE_PATH));
+        assertEquals(UriTemplate.fromTemplate("/base-path/params/query").queryParam("q1").queryParam("q2").build(),
+            uriTemplateParser.parseMethod(
+            UriBuilderTestControllers.ParamsController.class.getMethod("queryParams", String.class, long.class), BASE_PATH));
+        assertEquals(UriTemplate.fromTemplate("/base-path/params/matrix").matrixParam("m1").matrixParam("m2").build(),
+            uriTemplateParser.parseMethod(
+            UriBuilderTestControllers.ParamsController.class.getMethod("matrixParams", String.class, long.class), BASE_PATH));
     }
 
     @Test
     public void shouldParseFields() throws NoSuchMethodException {
-        assertThat(uriTemplateParser.parseMethod(UriBuilderTestControllers.FieldsController.class.getMethod("root"), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/fields/{p1}/{p2}/{p3}") //
-                .matrixParam("m1").matrixParam("m2").matrixParam("m3") //
-                .queryParam("q1").queryParam("q2").queryParam("q3").build())); //
+        assertEquals(UriTemplate.fromTemplate("/base-path/fields/{p1}/{p2}/{p3}") //
+            .matrixParam("m1").matrixParam("m2").matrixParam("m3") //
+            .queryParam("q1").queryParam("q2").queryParam("q3").build(),
+            uriTemplateParser.parseMethod(UriBuilderTestControllers.FieldsController.class.getMethod("root"), BASE_PATH));
     }
 
     @Test
     public void shouldParseBeanParams() throws NoSuchMethodException {
-        assertThat(uriTemplateParser.parseMethod(
-            UriBuilderTestControllers.BeanParamController.class.getMethod("bean", UriBuilderTestControllers.BeanParams.class), BASE_PATH),
-            equalTo(UriTemplate.fromTemplate("/base-path/bean/{p}").matrixParam("m").queryParam("q").build()));
+        assertEquals(UriTemplate.fromTemplate("/base-path/bean/{p}").matrixParam("m").queryParam("q").build(),
+            uriTemplateParser.parseMethod(
+            UriBuilderTestControllers.BeanParamController.class.getMethod("bean", UriBuilderTestControllers.BeanParams.class), BASE_PATH));
     }
 
 }

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -28,7 +28,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 /**
@@ -38,20 +37,20 @@ import static org.junit.Assert.*;
  */
 public class AnnotationUtilsTest {
 
-    private SomeController someController = new SomeController();
+    private final SomeController someController = new SomeController();
 
-    private SomeBean someBean = new SomeBean();
+    private final SomeBean someBean = new SomeBean();
 
     @Test
     public void getAnnotation() {
         Path path = AnnotationUtils.getAnnotation(someController.getClass(), Path.class);
-        assertThat(path.value(), is("start"));
+        assertEquals("start", path.value());
         Named named = AnnotationUtils.getAnnotation(someBean.getClass(), Named.class);
-        assertThat(named.value(), is("someBean"));
-        assertThat(AnnotationUtils.getAnnotation(BaseController.class, Controller.class), is(notNullValue()));
+        assertEquals("someBean", named.value());
+        assertNotNull(AnnotationUtils.getAnnotation(BaseController.class, Controller.class));
         // inheritance of class or interface annotations is not supported
-        assertThat(AnnotationUtils.getAnnotation(InheritedController.class, Controller.class), is(nullValue()));
-        assertThat(AnnotationUtils.getAnnotation(ControllerImpl.class, Controller.class), is(nullValue()));
+        assertNull(AnnotationUtils.getAnnotation(InheritedController.class, Controller.class));
+        assertNull(AnnotationUtils.getAnnotation(ControllerImpl.class, Controller.class));
     }
 
     @Test
@@ -69,18 +68,21 @@ public class AnnotationUtilsTest {
     @Test
     public void getAnnotationOnMethod() throws NoSuchMethodException {
         View view = AnnotationUtils.getAnnotation(someController.getClass().getMethod("start"), View.class);
-        assertThat(view.value(), is("start.jsp"));
+        assertNotNull(view.value());
+        assertEquals("start.jsp", view.value());
         NotNull notNull = AnnotationUtils.getAnnotation(someBean.getClass().getMethod("notNull"), NotNull.class);
-        assertThat(notNull.message(), is("notNull"));
-        assertThat(AnnotationUtils.getAnnotation(BaseController.class.getMethod("start"), View.class), is(notNullValue()));
-        assertThat(AnnotationUtils.getAnnotation(InheritedController.class.getMethod("start"), View.class), is(notNullValue()));
-        assertThat(AnnotationUtils.getAnnotation(ControllerImpl.class.getMethod("start"), View.class), is(notNullValue()));
+        assertNotNull(notNull.message());
+        assertEquals("notNull", notNull.message());
+        assertNotNull(AnnotationUtils.getAnnotation(BaseController.class.getMethod("start"), View.class));
+        assertNotNull(AnnotationUtils.getAnnotation(InheritedController.class.getMethod("start"), View.class));
+        assertNotNull(AnnotationUtils.getAnnotation(ControllerImpl.class.getMethod("start"), View.class));
         View inheritedView = AnnotationUtils.getAnnotation(InheritedControllerImpl.class.getMethod("start"), View.class);
-        // Annotations on a super-class take precedence over those on an implemented interface
-        assertThat(inheritedView.value(), is("start-base.jsp"));
+        assertNotNull(inheritedView);
+        assertEquals("Annotations on a super-class take precedence over those on an implemented interface",
+            "start-base.jsp", inheritedView.value());
         // if a subclass or implementation method has any MVC or JAX-RS annotations
-        // then all of the annotations on the superclass or interface method are ignored
-        assertThat(AnnotationUtils.getAnnotation(NoInheritanceController.class.getMethod("start"), Path.class), is(nullValue()));
+        // then all the annotations on the superclass or interface method are ignored
+        assertNull(AnnotationUtils.getAnnotation(NoInheritanceController.class.getMethod("start"), Path.class));
     }
 
     @Test
@@ -93,7 +95,7 @@ public class AnnotationUtilsTest {
         assertTrue(AnnotationUtils.hasAnnotation(InheritedController.class.getMethod("start"), View.class));
         assertTrue(AnnotationUtils.hasAnnotation(ControllerImpl.class.getMethod("start"), View.class));
         // if a subclass or implementation method has any MVC or JAX-RS annotations
-        // then all of the annotations on the superclass or interface method are ignored
+        // then all the annotations on the superclass or interface method are ignored
         assertFalse(AnnotationUtils.hasAnnotation(NoInheritanceController.class.getMethod("start"), Path.class));
     }
 

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -68,10 +68,8 @@ public class AnnotationUtilsTest {
     @Test
     public void getAnnotationOnMethod() throws NoSuchMethodException {
         View view = AnnotationUtils.getAnnotation(someController.getClass().getMethod("start"), View.class);
-        assertNotNull(view.value());
         assertEquals("start.jsp", view.value());
         NotNull notNull = AnnotationUtils.getAnnotation(someBean.getClass().getMethod("notNull"), NotNull.class);
-        assertNotNull(notNull.message());
         assertEquals("notNull", notNull.message());
         assertNotNull(AnnotationUtils.getAnnotation(BaseController.class.getMethod("start"), View.class));
         assertNotNull(AnnotationUtils.getAnnotation(InheritedController.class.getMethod("start"), View.class));

--- a/core/src/test/java/org/eclipse/krazo/util/BeanUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/BeanUtilsTest.java
@@ -23,9 +23,7 @@ import org.junit.Test;
 import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * The JUnit tests for the {@link BeanUtils} class.
@@ -37,9 +35,9 @@ public class BeanUtilsTest {
     @Test
     public void shouldFindFieldsAndAccessors() {
         List<AnnotatedElement> fieldsAndAccessors = BeanUtils.getFieldsAndAccessors(SomeBean.class);
-        assertThat(fieldsAndAccessors.size(), is(3));
+        assertEquals(3, fieldsAndAccessors.size());
         fieldsAndAccessors.forEach(fieldsAndAccessor ->
-            assertThat(fieldsAndAccessor.toString().toLowerCase(), containsString("foo"))
+            assertTrue(fieldsAndAccessor.toString().toLowerCase().contains("foo"))
         );
     }
 

--- a/core/src/test/java/org/eclipse/krazo/util/ControllerUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/ControllerUtilsTest.java
@@ -24,8 +24,8 @@ import jakarta.mvc.Controller;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * The JUnit tests for the {@link ControllerUtils} class.
@@ -36,40 +36,40 @@ public class ControllerUtilsTest {
 
     @Test
     public void shouldIdentifyControllerClasses() {
-        assertThat(ControllerUtils.isController(ClassController.class), is(true));
-        assertThat(ControllerUtils.isController(MethodController.class), is(true));
-        assertThat(ControllerUtils.isController(NoController.class), is(false));
+        assertTrue(ControllerUtils.isController(ClassController.class));
+        assertTrue(ControllerUtils.isController(MethodController.class));
+        assertFalse(ControllerUtils.isController(NoController.class));
     }
 
     @Test
     public void shouldIdentifyControllerMethods() throws NoSuchMethodException {
-        assertThat(ControllerUtils.isControllerMethod(ClassController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.isControllerMethod(ClassController.class.getMethod("bar")), is(true));
-        assertThat(ControllerUtils.isControllerMethod(MethodController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.isControllerMethod(MethodController.class.getMethod("bar")), is(true));
-        assertThat(ControllerUtils.isControllerMethod(NoController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.isControllerMethod(NoController.class.getMethod("bar")), is(false));
+        assertFalse(ControllerUtils.isControllerMethod(ClassController.class.getMethod("foo")));
+        assertTrue(ControllerUtils.isControllerMethod(ClassController.class.getMethod("bar")));
+        assertFalse(ControllerUtils.isControllerMethod(MethodController.class.getMethod("foo")));
+        assertTrue(ControllerUtils.isControllerMethod(MethodController.class.getMethod("bar")));
+        assertFalse(ControllerUtils.isControllerMethod(NoController.class.getMethod("foo")));
+        assertFalse(ControllerUtils.isControllerMethod(NoController.class.getMethod("bar")));
     }
 
     @Test
     public void shouldIdentifyRequestMethods() throws NoSuchMethodException {
-        assertThat(ControllerUtils.isRequestMethod(NoController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.isRequestMethod(NoController.class.getMethod("bar")), is(true));
-        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("bar")), is(true));
-        assertThat(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("foo")), is(true));
+        assertFalse(ControllerUtils.isRequestMethod(NoController.class.getMethod("foo")));
+        assertTrue(ControllerUtils.isRequestMethod(NoController.class.getMethod("bar")));
+        assertFalse(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("foo")));
+        assertTrue(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("bar")));
+        assertTrue(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("foo")));
         // if a subclass or implementation method has any MVC or JAX-RS annotations
-        // then all of the annotations on the superclass or interface method are ignored
-        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("baz")), is(false));
-        assertThat(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("baz")), is(false));
+        // then all the annotations on the superclass or interface method are ignored
+        assertFalse(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("baz")));
+        assertFalse(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("baz")));
     }
 
     @Test
     public void shouldIdentifyDeclaredRequestMethodAnnotations() throws NoSuchMethodException {
-        assertThat(ControllerUtils.hasDeclaredRequestMethodAnnotation(
-            MethodController.class.getMethod("foo")), is(false));
-        assertThat(ControllerUtils.hasDeclaredRequestMethodAnnotation(
-            MethodController.class.getMethod("bar")), is(true));
+        assertFalse(ControllerUtils.hasDeclaredRequestMethodAnnotation(
+            MethodController.class.getMethod("foo")));
+        assertTrue(ControllerUtils.hasDeclaredRequestMethodAnnotation(
+            MethodController.class.getMethod("bar")));
     }
 
     @Controller

--- a/core/src/test/java/org/eclipse/krazo/util/PathUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/PathUtilsTest.java
@@ -20,10 +20,7 @@ package org.eclipse.krazo.util;
 
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * The JUnit tests for the PathUtils class.
@@ -32,13 +29,15 @@ import static org.junit.Assert.assertTrue;
  */
 public class PathUtilsTest {
 
+    private static final String EMPTY_STRING = "";
+
 	@Test
 	public void noStartingSlash() {
-		assertThat(PathUtils.noStartingSlash("foo"), is("foo"));
-		assertThat(PathUtils.noStartingSlash("/foo"), is("foo"));
-		assertThat(PathUtils.noStartingSlash("/foo/"), is("foo/"));
-		assertThat(PathUtils.noStartingSlash("/"), is(""));
-		assertThat(PathUtils.noStartingSlash(""), is(""));
+        assertEquals("foo", PathUtils.noStartingSlash("foo"));
+        assertEquals("foo", PathUtils.noStartingSlash("/foo"));
+        assertEquals("foo/", PathUtils.noStartingSlash("/foo/"));
+        assertEquals(EMPTY_STRING, PathUtils.noStartingSlash("/"));
+        assertEquals(EMPTY_STRING, PathUtils.noStartingSlash(""));
 	}
 
 	@Test
@@ -51,44 +50,44 @@ public class PathUtilsTest {
 
 	@Test
 	public void noPrefix() {
-		assertThat(PathUtils.noPrefix("redirect:foo", "redirect:"), is("foo"));
-		assertThat(PathUtils.noPrefix("foo:bar", "bar"), is("foo:bar"));
-		assertThat(PathUtils.noPrefix("", ""), is(""));
+        assertEquals("foo", PathUtils.noPrefix("redirect:foo", "redirect:"));
+        assertEquals("foo:bar", PathUtils.noPrefix("foo:bar", "bar"));
+        assertEquals(EMPTY_STRING, PathUtils.noPrefix(EMPTY_STRING, EMPTY_STRING));
 	}
 
 	@Test
 	public void ensureStartingSlash() {
-		assertThat(PathUtils.ensureStartingSlash("foo"), is("/foo"));
-		assertThat(PathUtils.ensureStartingSlash("/foo"), is("/foo"));
-		assertThat(PathUtils.ensureStartingSlash("/foo/"), is("/foo/"));
-		assertThat(PathUtils.ensureStartingSlash("/"), is("/"));
-		assertThat(PathUtils.ensureStartingSlash(""), is("/"));
+		assertEquals("/foo", PathUtils.ensureStartingSlash("foo"));
+		assertEquals("/foo", PathUtils.ensureStartingSlash("/foo"));
+		assertEquals("/foo/", PathUtils.ensureStartingSlash("/foo/"));
+		assertEquals("/", PathUtils.ensureStartingSlash("/"));
+		assertEquals("/", PathUtils.ensureStartingSlash(""));
 	}
 
 	@Test
 	public void ensureEndingSlash() {
-		assertThat(PathUtils.ensureEndingSlash("foo"), is("foo/"));
-		assertThat(PathUtils.ensureEndingSlash("/foo"), is("/foo/"));
-		assertThat(PathUtils.ensureEndingSlash("/foo/"), is("/foo/"));
-		assertThat(PathUtils.ensureStartingSlash("/"), is("/"));
-		assertThat(PathUtils.ensureStartingSlash(""), is("/"));
+		assertEquals("foo/", PathUtils.ensureEndingSlash("foo"));
+		assertEquals("/foo/", PathUtils.ensureEndingSlash("/foo"));
+		assertEquals("/foo/", PathUtils.ensureEndingSlash("/foo/"));
+		assertEquals("/", PathUtils.ensureStartingSlash("/"));
+		assertEquals("/", PathUtils.ensureStartingSlash(EMPTY_STRING));
 	}
 
 	@Test
 	public void ensureNotEndingSlash() {
-		assertThat(PathUtils.ensureNotEndingSlash("foo/"), is("foo"));
-		assertThat(PathUtils.ensureNotEndingSlash("/foo/"), is("/foo"));
-		assertThat(PathUtils.ensureNotEndingSlash("/"), is(""));
-		assertThat(PathUtils.ensureNotEndingSlash(""), is(""));
+		assertEquals("foo", PathUtils.ensureNotEndingSlash("foo/"));
+		assertEquals("/foo", PathUtils.ensureNotEndingSlash("/foo/"));
+		assertEquals(EMPTY_STRING, PathUtils.ensureNotEndingSlash("/"));
+		assertEquals(EMPTY_STRING, PathUtils.ensureNotEndingSlash(""));
 	}
 
 	@Test
 	public void normalizePath() {
-		assertThat(PathUtils.normalizePath(""), is(""));
-		assertThat(PathUtils.normalizePath("/*"), is(""));
-		assertThat(PathUtils.ensureStartingSlash("/"), is("/"));
-		assertThat(PathUtils.normalizePath("/foo/bar/"), is("/foo/bar"));
-		assertThat(PathUtils.normalizePath("foo/bar"), is("/foo/bar"));
+		assertEquals(EMPTY_STRING, PathUtils.normalizePath(EMPTY_STRING));
+		assertEquals(EMPTY_STRING, PathUtils.normalizePath("/*"));
+		assertEquals("/", PathUtils.ensureStartingSlash("/"));
+		assertEquals("/foo/bar", PathUtils.normalizePath("/foo/bar/"));
+		assertEquals("/foo/bar", PathUtils.normalizePath("foo/bar"));
 	}
 
 }

--- a/core/src/test/java/org/eclipse/krazo/util/PropertyUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/PropertyUtilsTest.java
@@ -27,8 +27,7 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * The JUnit tests for the PropertyUtils class.
@@ -43,8 +42,8 @@ public class PropertyUtilsTest {
 		expect(config.getProperty(eq("host"))).andReturn("java.net");
 		expect(config.getProperty(eq("port"))).andReturn(null);
 		replay(config);
-		assertThat(PropertyUtils.getProperty(config, "host", "oracle.com"), is("java.net"));
-		assertThat(PropertyUtils.getProperty(config, "port", 8080), is(8080));
+		assertEquals("java.net", PropertyUtils.getProperty(config, "host", "oracle.com"));
+        assertEquals(8080, (long)PropertyUtils.getProperty(config, "port", 8080));
 		verify(config);
 	}
 

--- a/testsuite/src/test/java/org/eclipse/krazo/test/mapper/ExceptionMapperIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/mapper/ExceptionMapperIT.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,10 +35,8 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class ExceptionMapperIT {
@@ -48,7 +47,7 @@ public class ExceptionMapperIT {
     private WebClient webClient;
 
     @Deployment(testable = false)
-    public static Archive createDeployment() {
+    public static Archive<WebArchive> createDeployment() {
         return new WebArchiveBuilder()
             .addPackage("org.eclipse.krazo.test.mapper")
             .addView(new StringAsset("<h1>${message}</h1>"), "success.jsp")
@@ -70,10 +69,9 @@ public class ExceptionMapperIT {
         Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/success");
         WebResponse webResponse = page.getWebResponse();
 
-        assertThat(webResponse.getStatusCode(), equalTo(200));
-        assertThat(webResponse.getContentType(), startsWith("text/html"));
-        assertThat(webResponse.getContentAsString(),
-            containsString("<h1>Controller was executed without errors!</h1>"));
+        assertEquals(200, webResponse.getStatusCode());
+        assertTrue(webResponse.getContentType().startsWith("text/html"));
+        assertTrue(webResponse.getContentAsString().contains("<h1>Controller was executed without errors!</h1>"));
 
     }
 
@@ -83,10 +81,9 @@ public class ExceptionMapperIT {
         Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/fail-plain-text");
         WebResponse webResponse = page.getWebResponse();
 
-        assertThat(webResponse.getStatusCode(), equalTo(491));
-        assertThat(webResponse.getContentType(), startsWith("text/plain"));
-        assertThat(webResponse.getContentAsString(),
-            equalTo("Exception caught: Error thrown by controller"));
+        assertEquals(491, webResponse.getStatusCode());
+        assertTrue(webResponse.getContentType().startsWith("text/plain"));
+        assertEquals("Exception caught: Error thrown by controller", webResponse.getContentAsString());
 
     }
 
@@ -96,10 +93,9 @@ public class ExceptionMapperIT {
         Page page = webClient.getPage(baseURL.toString() + "mvc/mappers/fail-mvc-view");
         WebResponse webResponse = page.getWebResponse();
 
-        assertThat(webResponse.getStatusCode(), equalTo(492));
-        assertThat(webResponse.getContentType(), startsWith("text/html"));
-        assertThat(webResponse.getContentAsString(),
-            containsString("<h1>Exception caught: Error thrown by controller</h1>"));
+        assertEquals(492, webResponse.getStatusCode());
+        assertTrue(webResponse.getContentType().startsWith("text/html"));
+        assertTrue(webResponse.getContentAsString().contains("<h1>Exception caught: Error thrown by controller</h1>"));
 
     }
 }


### PR DESCRIPTION
See warn: <T>assertThat(T,org.hamcrest.Matcher<? super T>) in org.junit.Assert has been deprecated