### PR TITLE
[#233] Reactivating the Thymeleaf extension

### DIFF
--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
+    Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -43,8 +43,7 @@
 <!--        <module>jetbrick</module>-->
         <module>mustache</module>
         <module>stringtemplate</module>
-        <!-- remove until jakarta is supported by thymeleaf -->
-<!--        <module>thymeleaf</module>-->
+        <module>thymeleaf</module>
         <module>velocity</module>
         <module>pebble</module>
         <module>jinja2</module>

--- a/ext/thymeleaf/pom.xml
+++ b/ext/thymeleaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.krazo.ext</groupId>
         <artifactId>krazo-ext-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>krazo-thymeleaf</artifactId>
     <packaging>jar</packaging>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>3.0.11.RELEASE</version>
+            <version>3.1.0.M1</version>
         </dependency>
     </dependencies>
 </project>

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultJakartaServletWebApplicationWrapperProducer.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultJakartaServletWebApplicationWrapperProducer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.ext.thymeleaf;
+
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class DefaultJakartaServletWebApplicationWrapperProducer {
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Produces
+    @ApplicationScoped
+    public JakartaServletWebApplicationWrapper getJakartaServletWebApplicationWrapper() {
+        return new JakartaServletWebApplicationWrapper() {
+            private final JakartaServletWebApplication application = create();
+
+            @Override
+            public JakartaServletWebApplication get() {
+                return application;
+            }
+
+            private JakartaServletWebApplication create() {
+                final ServletContext servletContext = request.getServletContext();
+                return JakartaServletWebApplication.buildApplication(servletContext);
+            }
+        };
+    }
+
+}

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultTemplateEngineProducer.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/DefaultTemplateEngineProducer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ package org.eclipse.krazo.ext.thymeleaf;
 
 import org.eclipse.krazo.engine.ViewEngineConfig;
 import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
+import org.thymeleaf.templateresolver.WebApplicationTemplateResolver;
+import org.thymeleaf.web.servlet.IServletWebApplication;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
-import jakarta.servlet.ServletContext;
 
 /**
  * Producer for the TemplateEngine used by ThymeleafViewEngine.
@@ -36,13 +36,14 @@ import jakarta.servlet.ServletContext;
 public class DefaultTemplateEngineProducer {
 
     @Inject
-    private ServletContext servletContext;
+    private JakartaServletWebApplicationWrapper applicationWrapper;
 
     @Produces
     @ViewEngineConfig
     public TemplateEngine getTemplateEngine() {
 
-        ITemplateResolver resolver = new ServletContextTemplateResolver(this.servletContext);
+        IServletWebApplication servletApplication = applicationWrapper.get();
+        ITemplateResolver resolver = new WebApplicationTemplateResolver(servletApplication);
 
         TemplateEngine engine = new TemplateEngine();
         engine.setTemplateResolver(resolver);

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/JakartaServletWebApplicationWrapper.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/JakartaServletWebApplicationWrapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.ext.thymeleaf;
+
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
+
+/**
+ * Wrapper to circumvent {@link JakartaServletWebApplication} not being proxiable by CDI (because of it being final).
+ *
+ * @author Jeremias Weber
+ */
+public interface JakartaServletWebApplicationWrapper {
+
+    public JakartaServletWebApplication get();
+
+}

--- a/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/eclipse/krazo/ext/thymeleaf/ThymeleafViewEngine.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ package org.eclipse.krazo.ext.thymeleaf;
 import org.eclipse.krazo.engine.ViewEngineBase;
 import org.eclipse.krazo.engine.ViewEngineConfig;
 import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.web.IWebExchange;
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -29,7 +31,6 @@ import jakarta.inject.Inject;
 import jakarta.mvc.engine.ViewEngine;
 import jakarta.mvc.engine.ViewEngineContext;
 import jakarta.mvc.engine.ViewEngineException;
-import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -47,7 +48,7 @@ import java.util.Map;
 public class ThymeleafViewEngine extends ViewEngineBase {
 
     @Inject
-    private ServletContext servletContext;
+    private JakartaServletWebApplicationWrapper applicationWrapper;
 
     @Inject
     private BeanManager beanManager;
@@ -67,7 +68,10 @@ public class ThymeleafViewEngine extends ViewEngineBase {
             HttpServletRequest request = context.getRequest(HttpServletRequest.class);
             HttpServletResponse response = context.getResponse(HttpServletResponse.class);
 
-            CDIWebContext ctx = new CDIWebContext(beanManager, request, response, servletContext, context.getLocale());
+            JakartaServletWebApplication servletApplication = applicationWrapper.get();
+            IWebExchange exchange = servletApplication.buildExchange(request, response);
+
+            CDIWebContext ctx = new CDIWebContext(beanManager, exchange, context.getLocale());
 
             Map<String, Object> model = new HashMap<>(context.getModels().asMap());
             model.put("request", request);

--- a/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/ext/ThymeleafIT.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.assertTrue;
  * @author Gregor Tudan
  */
 @RunWith(Arquillian.class)
-@Ignore // Disabled, because jakarta.* package namespace not supported yet
 public class ThymeleafIT {
 
     private static final String WEB_INF_SRC = "src/main/resources/thymeleaf/";


### PR DESCRIPTION
This reenables the Thymeleaf extension by using its 3.1.0.M1 milestone release (which uses the jakarta namespace).

To adapt to changes in Thymeleaf, CDIWebContext had to be changed to use the jakarta namespace and the new IWebExchange. Since `JakartaServletWebApplication` has been established to wrap ServletContext in Thymeleaf, there needed to be a producer to inject it into both `DefaultTemplateEngineProducer` and `ThymeleafViewEngine`. But because `JakartaServletWebApplication` is a final class, a wrapper for it had to be written in order to use CDI.

Fixes #233