### PR TITLE
Implement specified form method overwrite

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
+++ b/core/src/main/java/org/eclipse/krazo/KrazoConfig.java
@@ -24,6 +24,7 @@ import org.eclipse.krazo.security.CsrfTokenStrategy;
 import org.eclipse.krazo.security.SessionCsrfTokenStrategy;
 
 import jakarta.inject.Inject;
+import jakarta.mvc.form.FormMethodOverwriter;
 import jakarta.mvc.security.Csrf;
 import jakarta.ws.rs.core.Configuration;
 
@@ -102,12 +103,21 @@ public class KrazoConfig {
         return RedirectScopeManager.DEFAULT_QUERY_PARAM_NAME;
     }
 
-    public boolean isHiddenMethodFilterActive() {
-        final Object value = config.getProperty(Properties.HIDDEN_METHOD_FILTER_ACTIVE);
-        if (value instanceof Boolean) {
-            return (boolean) value;
+    public FormMethodOverwriter.Options getFormMethodOverwriteOption() {
+        final Object value = config.getProperty(FormMethodOverwriter.FORM_METHOD_OVERWRITE);
+        if (value instanceof FormMethodOverwriter.Options) {
+            return (FormMethodOverwriter.Options) value;
         }
 
-        return false;
+        return FormMethodOverwriter.Options.ENABLED;
+    }
+
+    public String getFormMethodOverwriteField() {
+        final Object value = config.getProperty(FormMethodOverwriter.HIDDEN_FIELD_NAME);
+        if (value instanceof String) {
+            return String.valueOf(value);
+        }
+
+        return FormMethodOverwriter.DEFAULT_HIDDEN_FIELD_NAME;
     }
 }

--- a/core/src/main/java/org/eclipse/krazo/Properties.java
+++ b/core/src/main/java/org/eclipse/krazo/Properties.java
@@ -18,8 +18,6 @@
  */
 package org.eclipse.krazo;
 
-import org.eclipse.krazo.forms.HiddenMethodFilter;
-
 /**
  * Interface Properties. Application-level properties used to configure Krazo.
  *
@@ -28,15 +26,14 @@ import org.eclipse.krazo.forms.HiddenMethodFilter;
 public interface Properties {
 
     /**
-     * Boolean property that when set to {@code true} indicates Krazo to
-     * use cookies instead of the default URL re-write mechanism to implement
-     * redirect scope.
+     * Boolean property that when set to {@code true} indicates Krazo to use cookies instead of the default URL re-write
+     * mechanism to implement redirect scope.
      */
     String REDIRECT_SCOPE_COOKIES = "org.eclipse.krazo.redirectScopeCookies";
 
     /**
-     * String property that determines the name of the request attribute/parameter
-     * to be used in {@link org.eclipse.krazo.cdi.RedirectScopeManager}
+     * String property that determines the name of the request attribute/parameter to be used in
+     * {@link org.eclipse.krazo.cdi.RedirectScopeManager}
      */
     String REDIRECT_SCOPE_QUERY_PARAM_NAME = "org.eclipse.krazo.redirectScopeQueryParamName";
 
@@ -47,8 +44,7 @@ public interface Properties {
     String REDIRECT_SCOPE_COOKIE_NAME = "org.eclipse.krazo.redirectScopeCookieName";
 
     /**
-     * The implementation of {@link org.eclipse.krazo.security.CsrfTokenStrategy}
-     * to use for storing tokens.
+     * The implementation of {@link org.eclipse.krazo.security.CsrfTokenStrategy} to use for storing tokens.
      */
     String CSRF_TOKEN_STRATEGY = "org.eclipse.krazo.csrfTokenStrategy";
 
@@ -56,9 +52,4 @@ public interface Properties {
      * Property for defining default file extension for usage in views
      */
     String DEFAULT_VIEW_FILE_EXTENSION = "org.eclipse.krazo.defaultViewFileExtension";
-    
-    /**
-     * Boolean property which enables the {@link HiddenMethodFilter} when set to <code>true</code>.
-     */
-    String HIDDEN_METHOD_FILTER_ACTIVE = "org.eclipse.krazo.hiddenMethodFilterActive";
 }

--- a/core/src/main/java/org/eclipse/krazo/bootstrap/DefaultConfigProvider.java
+++ b/core/src/main/java/org/eclipse/krazo/bootstrap/DefaultConfigProvider.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.eclipse.krazo.binding.convert.MvcConverterProvider;
 import org.eclipse.krazo.core.ViewResponseFilter;
 import org.eclipse.krazo.core.ViewableWriter;
-import org.eclipse.krazo.forms.HiddenMethodFilter;
+import org.eclipse.krazo.forms.FormMethodOverwriteFilter;
 import org.eclipse.krazo.jaxrs.PostMatchingRequestFilter;
 import org.eclipse.krazo.jaxrs.PreMatchingRequestFilter;
 import org.eclipse.krazo.security.CsrfExceptionMapper;
@@ -50,7 +50,7 @@ public class DefaultConfigProvider implements ConfigProvider {
             PreMatchingRequestFilter.class,
             PostMatchingRequestFilter.class,
             MvcConverterProvider.class,
-            HiddenMethodFilter.class
+            FormMethodOverwriteFilter.class
         )
     );
 

--- a/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
+++ b/core/src/main/java/org/eclipse/krazo/cdi/KrazoCdiExtension.java
@@ -31,7 +31,7 @@ import org.eclipse.krazo.engine.FaceletsViewEngine;
 import org.eclipse.krazo.engine.JspViewEngine;
 import org.eclipse.krazo.engine.ViewEngineFinder;
 import org.eclipse.krazo.event.*;
-import org.eclipse.krazo.forms.HiddenMethodFilter;
+import org.eclipse.krazo.forms.FormMethodOverwriteFilter;
 import org.eclipse.krazo.jaxrs.JaxRsContextProducer;
 import org.eclipse.krazo.lifecycle.EventDispatcher;
 import org.eclipse.krazo.lifecycle.RequestLifecycle;
@@ -148,7 +148,7 @@ public class KrazoCdiExtension implements Extension {
                 UriTemplateParser.class,
 
                 // forms
-                HiddenMethodFilter.class
+                FormMethodOverwriteFilter.class
         );
     }
 

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfValidateFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfValidateFilter.java
@@ -148,7 +148,7 @@ public class CsrfValidateFilter implements ContainerRequestFilter {
      * Check if the controller wants to perform a write access. This means, in HTTP verbs, it wants
      * to perform a {@link POST}, {@link PUT}, {@link PATCH} or {@link DELETE} annotated method.
      *
-     * Because the {@link org.eclipse.krazo.forms.HiddenMethodFilter} enables us to use this methods in forms, we
+     * Because the {@link org.eclipse.krazo.forms.FormMethodOverwriteFilter} enables us to use this methods in forms, we
      * need to validate a Csrf token for them too, because the HTTP POST method is overwritten before this filter is entered.
      *
      * @param controller the controller method to check for write access

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
 
-        <tck.version>2.0.0</tck.version>
+        <tck.version>2.1.0-SNAPSHOT</tck.version>
         <!-- We don't deploy this module, because the TCK isn't in Maven Central yet -->
         <maven.deploy.skip>true</maven.deploy.skip>
 
@@ -193,6 +193,10 @@
                                     org.eclipse.krazo.tck.wildfly.WildflyArchiveProvider
                                 </jakarta.mvc.tck.api.BaseArchiveProvider>
                             </systemPropertyVariables>
+                            <argLine>
+                                --add-opens=java.base/java.security=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                            </argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
 
-        <tck.version>2.1.0-SNAPSHOT</tck.version>
+        <tck.version>2.1.0.M1</tck.version>
         <!-- We don't deploy this module, because the TCK isn't in Maven Central yet -->
         <maven.deploy.skip>true</maven.deploy.skip>
 

--- a/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/csrf/methods/CsrfHiddenMethodApplication.java
@@ -18,21 +18,9 @@
  */
 package org.eclipse.krazo.test.csrf.methods;
 
-import org.eclipse.krazo.Properties;
-
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
-import java.util.HashMap;
-import java.util.Map;
 
 @ApplicationPath("resources")
 public class CsrfHiddenMethodApplication extends Application {
-
-    @Override
-    public Map<String, Object> getProperties() {
-        final Map<String, Object> props = new HashMap<>();
-        props.put(Properties.HIDDEN_METHOD_FILTER_ACTIVE, true);
-
-        return props;
-    }
 }

--- a/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/forms/MyApplication.java
@@ -1,20 +1,8 @@
 package org.eclipse.krazo.test.forms;
 
-import org.eclipse.krazo.Properties;
-
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
-import java.util.HashMap;
-import java.util.Map;
 
 @ApplicationPath("resources")
 public class MyApplication extends Application {
-
-    @Override
-    public Map<String, Object> getProperties() {
-        final Map<String, Object> props = new HashMap<>();
-        props.put(Properties.HIDDEN_METHOD_FILTER_ACTIVE, true);
-
-        return props;
-    }
 }


### PR DESCRIPTION
This PR implements the newly specified feature 'form method overwrite' and fixes the TCK runner for WildFly on higher JDKs.

As Glassfish ships with a other version of Krazo, the TCK failed there. On WildFly 26 everything went fine. I'd recommend to release a Krazo milestone afterwards which maybe can be put into the Glassfish Beta, so we can test against it.