### PR TITLE
Improved proxy class detection mechanism (fixes #299)

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018-2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,11 @@ public final class AnnotationUtils {
     private static boolean isProxy(Class<?> clazz) {
         Class<?> parent = clazz.getSuperclass();
         if (parent != null) {
-            return clazz.getName().contains("$$") && clazz.getName().startsWith(parent.getName());
+            /*
+             * Checking for synthetic classes should actually be sufficient. However, for backwards compatibility
+             * we also check for the common naming pattern of Weld and OWB proxies.
+             */
+            return clazz.isSynthetic() || ( clazz.getName().contains( "$$" ) && clazz.getName().startsWith( parent.getName() ) );
         }
         return false;
     }


### PR DESCRIPTION
The TCK started to fail against Glassfish 7.0.0-SNAPSHOT (see #299 for details). 

One of the reasons seems to be that the latest Weld releases use a new naming pattern for CDI proxies, which causes our proxy detection mechanism to break. 

The old mechanism was based on the assumption that the FQCN of the proxy class this the name of the original class followed by `$$` and some fixes string. This isn't the case anymore as Weld seems to add an additional package prefix.

However, actually it should be sufficient to check if the class is synthetic and has a superclass.

Actually, we could even skip the class name pattern check and just check for the synthetic flag, but I decided to keep the old check for backwards compatibility.