### PR TITLE
Remove upper version bounds from OSGi Import-Package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
+    Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -103,6 +103,10 @@
                     <instructions>
                         <Bundle-SymbolicName>org.eclipse.krazo.core</Bundle-SymbolicName>
                         <Export-Package>org.eclipse.krazo.*</Export-Package>
+
+                        <!-- Use '>=3.0' instead of '[3.0,4)' for 'Import-Package' -->
+                        <_consumer-policy>$${versionmask;==}</_consumer-policy>
+
                     </instructions>
                 </configuration>
             </plugin>

--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
+    Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -73,6 +73,10 @@
                     <instructions>
                         <Bundle-SymbolicName>org.eclipse.krazo.jersey</Bundle-SymbolicName>
                         <Export-Package>org.eclipse.krazo.jersey.*</Export-Package>
+
+                        <!-- Use '>=3.0' instead of '[3.0,4)' for 'Import-Package' -->
+                        <_consumer-policy>$${versionmask;==}</_consumer-policy>
+
                     </instructions>
                 </configuration>
             </plugin>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Eclipse Krazo committers and contributors
+    Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -65,6 +65,10 @@
                     <instructions>
                         <Bundle-SymbolicName>org.eclipse.krazo.resteasy</Bundle-SymbolicName>
                         <Export-Package>org.eclipse.krazo.resteasy.*</Export-Package>
+
+                        <!-- Use '>=3.0' instead of '[3.0,4)' for 'Import-Package' -->
+                        <_consumer-policy>$${versionmask;==}</_consumer-policy>
+
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
 The same as https://github.com/eclipse-ee4j/mvc-api/pull/79, but for Krazo.