### PR TITLE
Remove producer for HttpServletRequest

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/core/ViewResponseFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewResponseFilter.java
@@ -100,7 +100,7 @@ public class ViewResponseFilter implements ContainerResponseFilter {
     @Context
     private ResourceInfo resourceInfo;
 
-    @Context
+    @Inject
     private HttpServletRequest request;
 
     @Inject

--- a/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
@@ -74,7 +74,7 @@ public class ViewableWriter implements MessageBodyWriter<Viewable> {
     @Inject
     private Instance<Models> modelsInstance;
 
-    @Context
+    @Inject
     private HttpServletRequest injectedRequest;
 
     @Context

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/JaxRsContextProducer.java
@@ -57,13 +57,6 @@ public class JaxRsContextProducer {
     @Produces
     @JaxRsContext
     @RequestScoped
-    public HttpServletRequest produceHttpServletRequest() {
-        return Objects.requireNonNull(request, "Cannot produce HttpServletRequest");
-    }
-
-    @Produces
-    @JaxRsContext
-    @RequestScoped
     public HttpServletResponse produceHttpServletResponse() {
         return Objects.requireNonNull(response, "Cannot produce HttpServletResponse");
     }

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PostMatchingRequestFilter.java
@@ -17,6 +17,7 @@
  */
 package org.eclipse.krazo.jaxrs;
 
+import jakarta.inject.Inject;
 import org.eclipse.krazo.util.CdiUtils;
 
 import jakarta.annotation.Priority;
@@ -43,7 +44,7 @@ public class PostMatchingRequestFilter implements ContainerRequestFilter {
     @Context
     private Configuration configuration;
 
-    @Context
+    @Inject
     private HttpServletRequest request;
 
     @Context

--- a/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
+++ b/core/src/main/java/org/eclipse/krazo/jaxrs/PreMatchingRequestFilter.java
@@ -17,6 +17,7 @@
  */
 package org.eclipse.krazo.jaxrs;
 
+import jakarta.inject.Inject;
 import org.eclipse.krazo.lifecycle.RequestLifecycle;
 import org.eclipse.krazo.util.CdiUtils;
 
@@ -43,7 +44,7 @@ public class PreMatchingRequestFilter implements ContainerRequestFilter {
     @Context
     private Configuration configuration;
 
-    @Context
+    @Inject
     private HttpServletRequest request;
 
     @Context

--- a/core/src/main/java/org/eclipse/krazo/security/CsrfTokenManager.java
+++ b/core/src/main/java/org/eclipse/krazo/security/CsrfTokenManager.java
@@ -42,7 +42,6 @@ public class CsrfTokenManager {
     private CsrfTokenStrategy tokenStrategy;
 
     @Inject
-    @JaxRsContext
     private HttpServletRequest request;
 
     @Inject


### PR DESCRIPTION
It seems that creating a HttpServletRequestBean by Krazo in the JaxRsContextProducer
leads to errors in the CDI TCK because there is already a default for HttpServletRequests
implemented. Removing this producer fixes two CDI tests.

see: #317