### PR TITLE
Update liberty arquillian settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <htmlunit.version>2.63.0</htmlunit.version>
         <arquillian-glassfish-remote-3.1.version>1.0.0.Final</arquillian-glassfish-remote-3.1.version>
         <wildfly-arquillian-container.version>5.0.0.Alpha3</wildfly-arquillian-container.version>
-        <arquillian-liberty-managed-jakarta.version>2.0.0-M1</arquillian-liberty-managed-jakarta.version>
+        <arquillian-liberty-managed-jakarta.version>2.0.2</arquillian-liberty-managed-jakarta.version>
 
         <!-- PLUGIN PROPERTIES -->
         <dependencyCheckSkip>true</dependencyCheckSkip>
@@ -499,6 +499,14 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
                 <version>${wildfly-arquillian-container.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.openliberty.arquillian</groupId>
+                <artifactId>arquillian-liberty-managed-jakarta-junit</artifactId>
+                <version>${arquillian-liberty-managed-jakarta.version}</version>
+                <type>pom</type>
                 <scope>test</scope>
             </dependency>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -282,14 +282,45 @@
                             <dependenciesToScan>jakarta.mvc.tck:mvc-tck-tests</dependenciesToScan>
                             <systemPropertyVariables>
                                 <arquillian.launch>liberty</arquillian.launch>
+                                <liberty.home>${project.build.directory}/liberty/wlp</liberty.home>
                                 <jakarta.mvc.tck.api.BaseArchiveProvider>
                                     org.eclipse.krazo.tck.liberty.LibertyArchiveProvider
                                 </jakarta.mvc.tck.api.BaseArchiveProvider>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
+
+                    <plugin>
+                        <groupId>io.openliberty.tools</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>3.3.4</version>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <serverName>defaultServer</serverName>
+                            <assemblyArtifact>
+                                <groupId>io.openliberty.beta</groupId>
+                                <artifactId>openliberty-runtime</artifactId>
+                                <version>22.0.0.8-beta</version>
+                                <type>zip</type>
+                            </assemblyArtifact>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>create-server</id>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <serverName>defaultServer</serverName>
+                                    <serverXmlFile>src/test/resources/liberty/server.xml</serverXmlFile>
+                                </configuration>
+                                <goals>
+                                    <goal>create</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
+
             <dependencies>
                 <dependency>
                     <groupId>io.openliberty.arquillian</groupId>

--- a/tck/src/test/resources/liberty/server.xml
+++ b/tck/src/test/resources/liberty/server.xml
@@ -16,6 +16,6 @@
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true"/>
 
-    <!-- Default SSL configuration enables trust for default certificates from the Java runtime --> 
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime -->
     <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
 </server>

--- a/tck/src/test/resources/liberty/server.xml
+++ b/tck/src/test/resources/liberty/server.xml
@@ -3,7 +3,7 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>jakartaee-9.0</feature>
+        <feature>jakartaee-9.1</feature>
         <feature>localConnector-1.0</feature>
     </featureManager>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -422,9 +422,9 @@
                             <skip>${skipTests}</skip>
                             <serverName>defaultServer</serverName>
                             <assemblyArtifact>
-                                <groupId>io.openliberty</groupId>
-                                <artifactId>openliberty-jakartaee9</artifactId>
-                                <version>22.0.0.7</version>
+                                <groupId>io.openliberty.beta</groupId>
+                                <artifactId>openliberty-runtime</artifactId>
+                                <version>22.0.0.8-beta</version>
                                 <type>zip</type>
                             </assemblyArtifact>
                         </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -49,14 +49,6 @@
                 <type>pom</type>
             </dependency>
 
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${shrinkwrap-resolver-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <!-- Define optional dependencies for the tests below -->
             <!-- EXT -->
             <dependency>
@@ -423,12 +415,41 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>io.openliberty.tools</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <version>3.3.4</version>
+                        <configuration>
+                            <skip>${skipTests}</skip>
+                            <serverName>defaultServer</serverName>
+                            <assemblyArtifact>
+                                <groupId>io.openliberty</groupId>
+                                <artifactId>openliberty-jakartaee9</artifactId>
+                                <version>22.0.0.7</version>
+                                <type>zip</type>
+                            </assemblyArtifact>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>create-server</id>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <serverName>defaultServer</serverName>
+                                    <serverXmlFile>src/test/resources/liberty/server.xml</serverXmlFile>
+                                </configuration>
+                                <goals>
+                                    <goal>create</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <skipITs>false</skipITs>
                             <systemProperties>
                                 <arquillian.launch>liberty</arquillian.launch>
                                 <testsuite.profile>testsuite-liberty</testsuite.profile>
+                                <liberty.home>${project.build.directory}/liberty/wlp</liberty.home>
                             </systemProperties>
                         </configuration>
                     </plugin>

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -70,8 +70,10 @@
     <container qualifier="liberty">
         <configuration>
             <property name="wlpHome">${liberty.home}</property>
+            <property name="serverName">defaultServer</property>
+            <property name="httpPort">9080</property>
             <!-- Uncomment for local debugging -->
-            <!-- <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=7777,server=y,suspend=y</property> -->
+             <property name="javaVmArguments">--add-opens=java.base/java.lang=ALL-UNNAMED</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/src/test/resources/liberty/server.xml
+++ b/testsuite/src/test/resources/liberty/server.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <feature>jakartaee-9.1</feature>
+        <feature>localConnector-1.0</feature>
+    </featureManager>
+
+    <!-- To access this server from a remote client add a host attribute
+        to the following element, e.g. host="*" -->
+    <httpEndpoint httpPort="9080" httpsPort="9443"
+                  id="defaultHttpEndpoint" />
+
+    <applicationMonitor updateTrigger="mbean" />
+
+    <!-- Default SSL configuration enables trust for default certificates from the Java runtime -->
+    <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+</server>


### PR DESCRIPTION
This enables us to launch the Open Liberty testsuite and TCK again.

Anyway, the testsuite fails because we don't implement some IBM specific wrapper and the TCK because
I'm not able to get the names of currently supported Jakarta EE 10 features, so the tests fail because of invalid `web.xml` versions. 

As those are managed environments, it won't be necessary to download the servers manually in Jenkins. I'll do the relevant changes there.