### PR TITLE
Improve documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fkrazo%2Fjob%2Fmaster-build-only%2F)
+![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fkrazo%2Fjob%2Fkrazo-ci%2Fjob%2Fmaster%2F)
 
 # Eclipse Krazo
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Java CI with Maven](https://github.com/eclipse-ee4j/krazo/actions/workflows/main.yml/badge.svg)](https://github.com/eclipse-ee4j/krazo/actions/workflows/main.yml)
+![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fkrazo%2Fjob%2Fmaster-build-only%2F)
 
 # Eclipse Krazo
 

--- a/documentation/src/main/asciidoc/_configuration.adoc
+++ b/documentation/src/main/asciidoc/_configuration.adoc
@@ -1,6 +1,6 @@
 ////
 
-    Copyright (c) 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2019-2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@
 
 == Configuration
 
-This section describes how you can configure your MVC application by overwriting properties inside the JAX-RS Application class.
-For example, you can overwrite a exemplary property `foo` inside the Application like this:
+This section describes how you can configure your MVC application by overwriting properties inside the Jakarta REST Application class.
+For example, you can overwrite an exemplary property `foo` inside the Application like this:
 
 [source,java]
 ....
@@ -42,20 +42,23 @@ public class MyApplication extends Application {
 
 For the usage of CSRF, the MVC API and Krazo provide different properties to customize its behavior.
 
-==== jakarta.mvc.security.CsrfProtection
+==== Csrf.CSRF_PROTECTION (jakarta.mvc.security.CsrfProtection)
 
 By default, the CSRF protection for MVC resources is set to `Csrf.CsrfOptions#EXPLICIT`, which means, that you're required to set the `@CsrfProtected` annotation over a Controller method annotated with `@POST`, `@PUT`, `@PATCH` or `@DELETE`.
 In case you want to use CSRF protection in all methods annotated with one of these HTTP verbs, you can set the property `jakarta.mvc.security.CsrfProtection` to `CsrfOptions#IMPLICIT`.
 
 [source,java]
 ....
+import jakarta.mvc.security.Csrf;
+import jakarta.mvc.security.Csrf.CsrfOptions;
+
 public class MyApplication extends Application {
 
     @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> props = new HashSet<>();
 
-        props.put("jakarta.mvc.security.CsrfProtection", CsrfOptions.IMPLICIT);
+        props.put(Csrf.CSRF_PROTECTION, CsrfOptions.IMPLICIT);
 
         return props;
     }
@@ -66,29 +69,32 @@ Although, you might want to disable CSRF protection completely for you applicati
 Therefore exists the `CsrfOptions#OFF` value, which can be set like the
 `CsrfOptions#IMPLICIT` value in the example above.
 
-==== jakarta.mvc.security.CsrfHeaderName
+==== Csrf.CSRF_HEADER_NAME (jakarta.mvc.security.CsrfHeaderName)
 
 Sometimes you may want to set a custom value for the header transporting the CSRF token.
-For this task you can use the property `jakarta.mvc.security.CsrfHeaderName`.
+For this task you can use the property `jakarta.mvc.security.CsrfHeaderName` or its constant `Csrf.CSRF_PROTECTION`.
 Overwriting this property will change the default name of the HTTP header from `X-CSRF-TOKEN` to any valid HTTP header name.
 The property can be changed like this:
 
 [source,java]
 ....
+import jakarta.mvc.security.Csrf;
+import jakarta.mvc.security.Csrf.CsrfOptions;
+
 public class MyApplication extends Application {
 
     @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> props = new HashSet<>();
 
-        props.put("jakarta.mvc.security.CsrfHeaderName", "X-CUSTOM-CSRF-HEADER");
+        props.put(Csrf.CSRF_HEADER_NAME, "X-CUSTOM-CSRF-HEADER");
 
         return props;
     }
 }
 ....
 
-==== org.eclipse.krazo.csrfTokenStrategy
+==== Properties.CSRF_TOKEN_STRATEGY (org.eclipse.krazo.csrfTokenStrategy)
 
 To generate CSRF tokens, Krazo provides two mechanisms by default: a cookie-based and a session-based algorithm, where the session-based is set as default.
 In case you want to change the strategy or even want to use some custom one, you can change the used strategy with the `org.eclipse.krazo.csrfTokenStrategy` property.
@@ -96,13 +102,16 @@ For example, you can switch to the cookie-based token strategy by using this set
 
 [source,java]
 ....
+import org.eclipse.krazo.Properties;
+import org.eclipse.krazo.security.CsrfTokenStrategy;
+
 public class MyApplication extends Application {
 
     @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> props = new HashSet<>();
 
-        props.put("org.eclipse.krazo.csrfTokenStrategy", CookieCsrfTokenStrategy.Builder.build());
+        props.put(Properties.CSRF_TOKEN_STRATEGY, CookieCsrfTokenStrategy.Builder.build());
 
         return props;
     }
@@ -117,27 +126,78 @@ Please have a look into the JavaDoc for this.
 Eclipse Krazo provides some configuration properties, where someone can customize the behavior of the view handling.
 These configurations will be described in the following sections.
 
-==== org.eclipse.krazo.redirectScopeCookies
+==== Properties.REDIRECT_SCOPE_COOKIES (org.eclipse.krazo.redirectScopeCookies)
 
-By default, Krazo uses a URL re-write mechanism to store the information about `@RedirectScope`d beans. In case someone doesn't want this behavior, Krazo
-                                                                                also supports a cookie-based strategy for this task. To enable this feature, the property `org.eclipse.krazo.redirectScopeCookies` needs to be overwritten inside the JAX-RS Application class:
+By default, Krazo uses a URL re-write mechanism to store the information about `@RedirectScoped` beans.
+In case someone doesn't want this behavior, Krazo also supports a cookie-based strategy for this task. To enable this feature, the property `org.eclipse.krazo.redirectScopeCookies` needs to be overwritten inside the Jakarta REST Application class:
 
 [source,java]
 ....
+import org.eclipse.krazo.Properties;
+
 public class MyApplication extends Application {
 
     @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> props = new HashSet<>();
 
-        props.put("org.eclipse.krazo.redirectScopeCookies", true);
+        props.put(Properties.REDIRECT_SCOPE_COOKIES, true);
 
         return props;
     }
 }
 ....
 
-==== org.eclipse.krazo.defaultViewFileExtension
+==== Properties.REDIRECT_SCOPE_COOKIE_NAME (org.eclipse.krazo.redirectScopeCookieName)
+
+When you use the _cookie based_ approach to handle the redirect scope, the default cookie name is `org.eclipse.krazo.redirect.Cookie`. In case this name doesn't match your requirements, there is a property called `org.eclipse.krazo.redirectScopeCookieName` to overwrite it. The example shows how this can be achieved.
+
+[source,java]
+....
+import org.eclipse.krazo.Properties;
+
+public class MyApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> props = new HashSet<>();
+
+        props.put(Properties.REDIRECT_SCOPE_COOKIE_NAME, "my_redirect_cookie");
+
+        return props;
+    }
+}
+....
+
+This example would let Krazo create a Cookie called `my_redirect_cookie` containing the redirect scope token.
+
+==== Properties.REDIRECT_SCOPE_QUERY_PARAM_NAME (org.eclipse.krazo.redirectScopeQueryParamName)
+
+On the other hand, when you use the _query param_ based approach, which is the default setting, you can
+change the query param's name from `org.eclipse.krazo.redirect.param.ScopeId` to something more concise by using
+the property `org.eclipse.krazo.redirectScopeQueryParamName`. The example shows to how this can be done inside the
+Jakarta REST application.
+
+[source,java]
+....
+import org.eclipse.krazo.Properties;
+
+public class MyApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> props = new HashSet<>();
+
+        props.put(Properties.REDIRECT_SCOPE_QUERY_PARAM_NAME, "redirect_token");
+
+        return props;
+    }
+}
+....
+
+Now the query param would be something like `/foo?redirect_token=[some UUID]` instead of `/foo?org.eclipse.krazo.redirect.param.ScopeId=[some UUID]`.
+
+==== Properties.DEFAULT_VIEW_FILE_EXTENSION (org.eclipse.krazo.defaultViewFileExtension)
 
 While developing a completely new MVC application, someone normally just uses one template engine for all of its views.
 This means, that every view file ends with the same extension and this leads to less readable code.
@@ -146,13 +206,15 @@ To set this extension as a default for all view files, Krazo provides the proper
 
 [source,java]
 ....
+import org.eclipse.krazo.Properties;
+
 public class MyApplication extends Application {
 
     @Override
     public Map<String, Object> getProperties() {
         final Map<String, Object> props = new HashSet<>();
 
-        props.put("org.eclipse.krazo.defaultViewFileExtension", "jsp");
+        props.put(Properties.DEFAULT_VIEW_FILE_EXTENSION, "jsp");
 
         return props;
     }

--- a/documentation/src/main/asciidoc/_extensions.adoc
+++ b/documentation/src/main/asciidoc/_extensions.adoc
@@ -1,6 +1,6 @@
 ////
 
-    Copyright (c) 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2019-2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,6 +17,105 @@
     SPDX-License-Identifier: Apache-2.0
 
 ////
+[#_writing_extensions]
 == Writing Extensions
 
-TODO: Describe Krazo extension points and SPIs
+This chapter explains, what steps need to be taken to extend Krazo's functionality. This may be additional
+configurations, type converters or whole view engines.
+
+Most of those SPIs (Service Provider Interfaces) are handled by Java's link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html[ServiceLoader] mechanism. Please read its documentation before you start to implement Krazo extensions.
+
+=== Add type converters
+
+Eclipse Krazo provides its own implementation of Jakarta RESTs `ParamConverterProvider`, so the `BindingResult` can be filled in case of an incompatible mapping between the request's and target's type.
+You can add custom implementations of `org.eclipse.krazo.binding.convert.MvcConverter` and register them as a service, so it can be picked up by the `org.eclipse.krazo.binding.convert.ConverterRegistry`. Converts can be prioritized by the `@Priority` annotation. The default priority of all embedded `MvcConverter` implementations is `0 (zero)`.
+
+You can find an example for adding a new `MvcConverter` in the link:https://github.com/eclipse-ee4j/krazo/blob/master/testsuite/src/test/java/org/eclipse/krazo/test/convert/ConverterPriorityIT.java[ConverterPriorityIT]. Please note, that the service registration is link:https://github.com/eclipse-ee4j/krazo/blob/ad02db7cc262bd40275045528113ccb42c088b47/testsuite/src/test/java/org/eclipse/krazo/test/convert/ConverterPriorityIT.java#L39[handled by
+Arquillian] in this case.
+
+=== Add features to Jakarta RESTful Web Services
+
+To be usable on top of Jakarta REST, Eclipse Krazo uses a lot of Jakarta REST APIs. One of them is the `FeatureContext` which is used to register providers, filters etc. The core classes of Krazo are registered there too, which is made possible by the `org.eclipse.krazo.bootstrap.ConfigProvider` interface. This interface needs to be implemented in case an extension wants to add additional behavior to Krazo and registered as a service. Then, on application startup, all `ConfigProvider` implementations are fetched by `org.eclipse.krazo.bootstrap.Initializer` and registered in Jakarta REST.
+
+The `ConfigProvider` implementations for link:https://github.com/eclipse-ee4j/krazo/blob/master/jersey/src/main/java/org/eclipse/krazo/jersey/bootstrap/JerseyConfigProvider.java[krazo-jersey] and link:https://github.com/eclipse-ee4j/krazo/blob/master/resteasy/src/main/java/org/eclipse/krazo/resteasy/bootstrap/RestEasyConfigProvider.java[krazo-resteasy] are good example for the usage of this SPI.
+
+=== Unwrap HTTP communication for different servers
+
+As there is more than one implementation of Jakarta REST, there may be different behaviors when it comes to
+request and response handling. Some implementations wrap the original `HttpServletRequest` and / or `HttpServletResponse` which makes it hard to work on the specified API. Eclipse Krazo provides an SPI which
+makes it possible to unwrap such non-standard behavior, namely the `org.eclipse.krazo.core.HttpCommunicationUnwrapper`. This interface can be used to unwrap incoming requests an responses so Krazo can handle them.
+
+One real-world example on how this interface can be used is the link:https://github.com/eclipse-ee4j/krazo/blob/master/resteasy/src/main/java/org/eclipse/krazo/resteasy/core/LibertyHttpCommunicationUnwrapper.java[LibertyHttpCommunicationUnwrapper] used to normalize the request coming from OpenLiberty.
+
+=== Custom behavior for form handling during CSRF validation
+
+To be able to receive the CSRF token from HTML forms, an implementation of the `org.eclipse.krazo.security.FormEntityProvider` is required. At the moment, only the content type `application/x-www-form-urlencoded` is supported. Anyway, sometimes there is different behavior between Jakarta REST implementations or their integration into application servers, so a custom `FormEntityProvider` is required. Those custom implementations need to be registered as service.
+
+To give you an example implementation, you can have a look into link:https://github.com/eclipse-ee4j/krazo/blob/master/resteasy/src/main/java/org/eclipse/krazo/resteasy/security/RestEasyFormEntityProvider.java[org.eclipse.krazo.resteasy.security.RestEasyFormEntityProvider] to see how
+this provider can be used to handle the behavior of RESTEasy forms.
+
+=== Creating your own view engine
+
+The last extension point is more or less one single interface you need to know when you want to add a custom view engine. To have a real-world example the link:https://github.com/eclipse-ee4j/krazo-extensions/tree/main/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker[Krazo Freemarker extension] will be described. This one is chosen because it requires the minimum amount of configuration. More advanced example can be found e. g. in the link:https://github.com/eclipse-ee4j/krazo-extensions/tree/main/thymeleaf[Krazo Thymeleaf extension].
+
+A view engine is in most of the cases just an implementation of the `jakarta.mvc.engine.ViewEngine` interface which
+contains the following two methods:
+
+- `boolean supports(String view)`
+- `void processView(ViewEngineContext context)`
+
+So a view engine requires to return which views are supported, which is done by checking them for specific file suffixes. The link:https://github.com/eclipse-ee4j/krazo-extensions/blob/main/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/FreemarkerViewEngine.java[FreemarkerViewEngine] for example is triggered, when a view ends on `.ftl`.
+
+[source,java]
+....
+@ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
+public class FreemarkerViewEngine extends ViewEngineBase {
+
+    @Override
+    public boolean supports(String view) {
+        return view.endsWith(".ftl");
+    }
+
+    //...
+}
+....
+
+And in case the view engine is identified as engine-to-use for the current view, it needs to get processed. This is done inside the `processView` method:
+
+[source,java]
+....
+@ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
+public class FreemarkerViewEngine extends ViewEngineBase {
+
+    @Inject
+    @ViewEngineConfig
+    private Configuration configuration;
+
+	//...
+
+    @Override
+    public void processView(ViewEngineContext context) throws ViewEngineException {
+
+        Charset charset = resolveCharsetAndSetContentType(context);
+
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
+
+            Template template = configuration.getTemplate(resolveView(context));
+
+            Map<String, Object> model = new HashMap<>(context.getModels().asMap());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            template.process(model, writer);
+
+        } catch (TemplateException | IOException e) {
+            throw new ViewEngineException(e);
+        }
+    }
+}
+....
+
+As you can see, there's no magic inside. The charset of the view is resolved, which is done by the abstract `ViewEngineBase` class that implements the `ViewEngine` interface and the template loaded via the `Configuration` class. The `Configuration` class is a FreeMarker API that is produced in the bean link:https://github.com/eclipse-ee4j/krazo-extensions/blob/main/freemarker/src/main/java/org/eclipse/krazo/ext/freemarker/DefaultConfigurationProducer.java[DefaultConfigurationProducer] and injected by CDI. Afterwards, the model is migrated into the type FreeMarker expects as its model and the template gets processed.
+
+Concluding this topic, as you can see creating an own Krazo view engine is not hard from Krazo's point of view and the `ViewEngine` interface provides everything you need to get started.

--- a/documentation/src/main/asciidoc/_intro.adoc
+++ b/documentation/src/main/asciidoc/_intro.adoc
@@ -1,6 +1,6 @@
 ////
 
-    Copyright (c) 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2019-2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,9 +19,8 @@
 ////
 == Introduction
 
-Eclipse Krazo is an implementation of action-based MVC specified by Jakarta MVC 2.0.
-It builds on top of Jakarta RESTful Webservices (former JAX-RS)  and currently contains support for RESTEasy and Jersey
+Eclipse Krazo is an implementation of action-based MVC specified by Jakarta MVC.
+It builds on top of Jakarta RESTful Web Services (former JAX-RS; abbreviated with Jakarta REST inside this documentation)  and currently contains support for RESTEasy and Jersey
 with a well-defined SPI for other implementations.
 
-This is user guide for Eclipse Krazo {krazo-version}.
-We are trying to keep it up to date as we add new features.
+This is the user guide for Eclipse Krazo {krazo-version}. We are trying to keep it up to date with the current features. Please note, that this guide assumes that the examples are, if not specified otherwise, targeting a Jakarta EE 10 environment.

--- a/documentation/src/main/asciidoc/_quickstart.adoc
+++ b/documentation/src/main/asciidoc/_quickstart.adoc
@@ -1,6 +1,6 @@
 ////
 
-    Copyright (c) 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2019-2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,16 +24,20 @@ This section describes how to set up Eclipse Krazo.
 === Basic setup
 
 The required steps to set up Eclipse Krazo depends on your environment. The easiest way is to
-use a Java EE 8 / Jakarta EE environment, because in this case the server already provides all the
+use a Jakarta EE environment, because in this case the server already provides all the
 prerequisites.
 
-==== Java EE 8 / Jakarta EE
+==== Jakarta EE
 
 The easiest way getting started with Eclipse Krazo is to generate a Jakarta EE project with our
 archetype. This archetype generates a simple project including the Jakarta EE Web Profile and the selected,
 server-specific Krazo implementation.
 
-This archetype will use Jakarta EE 8 until version 1.1.0 of Krazo and Jakarta EE 9 since version 2.0.0.
+This archetype comes with the following setups:
+
+- Java EE 8 / Jakarta EE 8: MVC 1.0, Krazo 1.1.0
+- Jakarta EE 9: MVC 2.0, Krazo 2.0.x
+- Jakarta EE 10: MVC 2.1, Krazo 3.0.0
 
 ===== How to use the archetype
 
@@ -41,53 +45,24 @@ The usage of the archetype is really easy. Depending on your application server,
 
 ====== Glassfish / Payara (Jersey)
 
-For Java EE 8 / Jakarta EE 8:
-
 [source, subs="attributes"]
 ----
 mvn archetype:generate \
 -DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee8-archetype \
--DarchetypeVersion={krazo-version}  \
+-DarchetypeArtifactId=krazo-jakartaee[8|9|10]-archetype \
+-DarchetypeVersion=[1.1.0 | 2.0.x | 3.0.0]  \
 -DgroupId=YOUR GROUP ID\
 -DartifactId=YOUR ARTIFACT ID
 ----
 
-For Jakarta EE 9:
+====== Wildfly (RESTEasy) / OpenLiberty >= 21.x
 
 [source, subs="attributes"]
 ----
 mvn archetype:generate \
 -DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee9-archetype \
--DarchetypeVersion={krazo-version}  \
--DgroupId=YOUR GROUP ID\
--DartifactId=YOUR ARTIFACT ID
-----
-
-====== Wildfly (RESTEasy) / OpenLiberty 21.* and newer
-
-For Java EE 8 / Jakarta EE 8:
-
-[source, subs="attributes"]
-----
-mvn archetype:generate \
--DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee8-archetype \
--DarchetypeVersion={krazo-version} \
--DgroupId=YOUR GROUP ID \
--DartifactId=YOUR ARTIFACT ID \
--DkrazoImpl=resteasy
-----
-
-For Jakarta EE 9:
-
-[source, subs="attributes"]
-----
-mvn archetype:generate \
--DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee9-archetype \
--DarchetypeVersion={krazo-version} \
+-DarchetypeArtifactId=krazo-jakartaee[8|9|10]-archetype \
+-DarchetypeVersion=[1.1.0 | 2.0.x | 3.0.0] \
 -DgroupId=YOUR GROUP ID \
 -DartifactId=YOUR ARTIFACT ID \
 -DkrazoImpl=resteasy
@@ -96,205 +71,139 @@ mvn archetype:generate \
 ====== TomEE / OpenLiberty (CXF)
 Krazo won't support CXF anymore. As OpenLiberty is going to switch to RESTEasy until it supports Jakarta REST Web Services 3.0, this change is only relevant for TomEE in general and older versions of OpenLiberty.
 
-To use Krazo on those servers anyway, you can add e.g. RESTEasy as a compile time dependency to your artifact:
-
-[source,xml]
-----
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-resteasy</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-cdi</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-validator-provider-11</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-----
-
+To use Krazo on those servers anyway, you can add Jersey or RESTEasy as a compile time dependency to your artifact/
 
 ====== Glassfish/Payara
 
-Glassfish comes with Jersey as its JAX-RS implementation. Please add the following dependencies to your
+Glassfish comes with Jersey as its Jakarta REST implementation. Please add the following dependencies to your
 application:
 
 [source,xml]
 ----
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-jersey</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>jakarta.mvc</groupId>
+        <artifactId>jakarta.mvc-api</artifactId>
+        <version>{{versions.spec.latest}}</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.eclipse.krazo</groupId>
+        <artifactId>krazo-jersey</artifactId>
+        <version>{{versions.krazo.latest}}</version>
+    </dependency>
+
+    <!-- other dependencies ... -->
+</dependencies>
 ----
 
-====== Wildfly, JBoss EAP and OpenLiberty 21.*
+====== Wildfly, JBoss EAP and OpenLiberty >= 21.x
 
-Wildfly is using RESTEasy for JAX-RS. So you need the Eclipse Krazo RESTEasy integration module:
+Wildfly is using RESTEasy for Jakarta REST. So you need the Eclipse Krazo RESTEasy integration module:
 
 [source,xml]
 ----
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-resteasy</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
-----
+<dependencies>
+    <dependency>
+        <groupId>jakarta.mvc</groupId>
+        <artifactId>jakarta.mvc-api</artifactId>
+        <version>{{versions.spec.latest}}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.eclipse.krazo</groupId>
+        <artifactId>krazo-resteasy</artifactId>
+        <version>{{versions.krazo.latest}}</version>
+    </dependency>
 
-In the future, OpenLiberty will use RESTEasy also, so it will have the same setup.
-
-====== Apache TomEE
-
-To use Krazo on TomEE, you can add RESTEasy as a compile time dependency, as CXF isn't supported anymore by Krazo.
-
-[source,xml]
-----
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-resteasy</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-cdi</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-validator-provider-11</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
+    <!-- other dependencies ... -->
+</dependencies>
 ----
 
 ====== Thorntail
 
-Since version 2.7.0, Thorntail provides a stable fraction for MVC with Krazo. For older versions of Thorntail you can use the JAX-RS fraction and add
-the same dependencies as required for WildFly:
+Since version 2.7.0, Thorntail provides a stable fraction for MVC with Krazo. For older versions of Thorntail you can use the Jakarta REST fraction and add
+the same dependencies as required for WildFly.
 
-[source,xml]
-----
-<dependency>
-    <groupId>io.thorntail</groupId>
-    <artifactId>jaxrs</artifactId>
-</dependency>
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-resteasy</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
-----
-
-using fraction :
-
-[source,xml]
-----
-<dependency>
-    <groupId>io.thorntail</groupId>
-    <artifactId>mvc</artifactId>
-</dependency>
-----
-
-Please note, that Thorntail link:https://thorntail.io/posts/the-end-of-an-era/[reached end of life] and therefore the MVC fraction will only receive critical bug fixes.
+Please note, that Thorntail link:https://thorntail.io/posts/the-end-of-an-era/[reached end of life] and therefore the MVC fraction won't receive updates anymore.
 
 ==== Servlet Containers
 
 The simplest way to get started with MVC is to deploy your app to a JavaEE 8 application server.
-In this setup the application server will provide JAX-RS, CDI and Bean Validation implementations
+In this setup the application server will provide Jakarta REST, CDI and Bean Validation implementations
 for you. However, there is a large number of users who prefer to run their applications on plain Servlet containers
-like Apache Tomcat and Jetty. In this setup you will have to provide JAX-RS, CDI and Bean Validations
+like Apache Tomcat and Jetty. In this setup you will have to provide Jakarta REST, CDI and Bean Validations
 yourself.
 
-The following steps will show you how to run Eclipse Krazo on Apache Tomcat using Weld, RESTEasy and Hibernate Validator.
+The following steps will show you how to run Eclipse Krazo on Apache Tomcat using Weld, Jersey and Hibernate Validator (used by Jersey Bean Validation).
 
 === Required dependencies
 
-The following `pom.xml` example shows the dependency configuration for your application:
+The following `pom.xml` example shows the dependency configuration for your application. Please use the corresponding versions according to the Jakarta EE platform you target.
 
 [source,xml]
 ----
-<!-- Get the API JARs for Jakarta EE 8 -->
-<dependency>
-    <groupId>jakarta.platform</groupId>
-    <artifactId>jakarta.jakartaee-web-api</artifactId>
-    <version>8.0.0</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <scope>compile</scope>
+    </dependency>
 
-<!-- Weld  -->
-<dependency>
-    <groupId>org.jboss.weld.servlet</groupId>
-    <artifactId>weld-servlet-core</artifactId>
-    <version>3.0.5.Final</version>
-</dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-server</artifactId>
+    </dependency>
 
-<!-- RESTEasy -->
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-cdi</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-servlet-initializer</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.core</groupId>
+        <artifactId>jersey-common</artifactId>
+        <scope>compile</scope>
+    </dependency>
 
-<!-- Bean Validation -->
-<dependency>
-    <groupId>org.jboss.resteasy</groupId>
-    <artifactId>resteasy-validator-provider-11</artifactId>
-    <version>3.6.1.Final</version>
-</dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.containers</groupId>
+        <artifactId>jersey-container-servlet</artifactId>
+    </dependency>
 
-<!-- MVC + Eclipse Krazo for RESTEasy-->
-<dependency>
-    <groupId>jakarta.mvc</groupId>
-    <artifactId>jakarta.mvc-api</artifactId>
-    <version>{{versions.spec.latest}}</version>
-</dependency>
-<dependency>
-    <groupId>org.eclipse.krazo</groupId>
-    <artifactId>krazo-resteasy</artifactId>
-    <version>{{versions.krazo.latest}}</version>
-</dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+        <artifactId>jersey-hk2</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.glassfish.jersey.ext</groupId>
+        <artifactId>jersey-bean-validation</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.jboss.weld.servlet</groupId>
+        <artifactId>weld-servlet-core</artifactId>
+        <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>org.glassfish.jersey.ext.cdi</groupId>
+        <artifactId>jersey-cdi1x-servlet</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>org.eclipse.krazo</groupId>
+        <artifactId>krazo-jersey</artifactId>
+        <version>${krazo.version}</version>
+    </dependency>
+</dependencies>
 ----
 
 === Configuration files
@@ -306,63 +215,33 @@ Make sure to add an empty `beans.xml` file in your `/src/main/webapp/WEB-INF` fo
 <?xml version="1.0"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       version="3.0" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0">
 
 </beans>
 ----
 
-Please also add a file called `context.xml` to `src/main/resources/META-INF`:
+Please note, that the default `bean-discovery-mode` changed to `annotated` in CDI 4.0. In case you want to use the old behavior, set the `bean-discovery-mode` to `all` in the `beans.xml`
 
-[source,xml]
-----
-<?xml version="1.0" encoding="UTF-8"?>
-<Context>
-
-   <Resource name="BeanManager" auth="Container"
-             type="jakarta.enterprise.inject.spi.BeanManager"
-             factory="org.jboss.weld.resources.ManagerObjectFactory"/>
-
-</Context>
-----
-
-This file `context.xml` is essential for the operation of the CDI in Tomcat as described in the
-link:http://docs.jboss.org/weld/reference/latest/en-US/html_single/#tomcat[Weld documentation].
-
-The file to create is called `web.xml` and should be placed in the `src/main/webapp/WEB-INF` directory:
+The next file to create is called `web.xml` and should be placed in the `src/main/webapp/WEB-INF` directory:
 
 [source,xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_4_0.xsd"
-         version="4.0" metadata-complete="true">
-
-  <listener>
-    <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
-  </listener>
-
-  <resource-env-ref>
-    <resource-env-ref-name>BeanManager</resource-env-ref-name>
-    <resource-env-ref-type>jakarta.enterprise.inject.spi.BeanManager</resource-env-ref-type>
-  </resource-env-ref>
-
-  <!-- http://docs.jboss.org/resteasy/docs/3.6.1.Final/userguide/html_single/index.html#d4e143 -->
-  <context-param>
-    <param-name>resteasy.injector.factory</param-name>
-    <param-value>org.jboss.resteasy.cdi.CdiInjectorFactory</param-value>
-  </context-param>
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+         version="5.0" metadata-complete="true">
 
 </web-app>
 ----
 
 The attribute `metadata-complete` isn't madantory, but link:https://issues.jboss.org/browse/RESTEASY-2289[helps to prevent Krazo starting twice on RESTEasy]
 
-==== Mixed configuration with Application#getClasses and JAX-RS auto discovery
+==== Mixed configuration with Application#getClasses and Jakarta REST auto discovery
 
-As an alternative to the resource auto-discovery of JAX-RS, someone can use `Application#getClasses` to configure
-endpoints or other providers. Unfortunately, this disables the auto-discovery of JAX-RS completely, which leads to
+As an alternative to the resource auto-discovery of Jakarta REST, someone can use `Application#getClasses` to configure
+endpoints or other providers. Unfortunately, this disables the auto-discovery of Jakarta REST completely, which leads to
 not loaded Krazo classes and errors or misbehavior during runtime. In case you want to use the manual approach together
 with Eclipse Krazo, you have to consider following configurations.
 
@@ -374,7 +253,7 @@ You don't need additional configuration, as Krazo is auto-loaded by implementati
 
 The following steps will show you how to create your first Controller using Eclipse Krazo. It assumes, that you've set up a project like we described before.
 
-The first step is to create an Application class, which serves as root resource for our Controllers. The Application class extends from JAX-RS `Application` and provides
+The first step is to create an Application class, which serves as root resource for our Controllers. The Application class extends from Jakarta REST `Application` and provides
 the base path of our application.
 
 [source,java]
@@ -388,10 +267,9 @@ public class MyApplication extends Application {
 }
 ....
 
-Please note that, according to the MVC specification, it is not recommended to use an empty application path, as this can lead to problems during request handling.
+Please note that, according to the MVC specification, it is not recommended to use an empty application path, as this can lead to problems during request handling when using servlets and MVC resources in parallel or whenyou try to access a stylesheet served by the servlet container via `src/main/webapp`.
 
-After we created the Application class, we need to add our Controller. Therefore you need to add a simple JAX-RS resource and decorate it with the
-`jakarta.mvc.Controller` interface.
+After we created the Application class, we need to add our Controller. Therefore, you need to add a simple Jakarta REST resource and decorate it with the `jakarta.mvc.Controller` annotation.
 
 
 [source,java]

--- a/documentation/src/main/asciidoc/_view-engines.adoc
+++ b/documentation/src/main/asciidoc/_view-engines.adoc
@@ -1,6 +1,6 @@
 ////
 
-    Copyright (c) 2019 Eclipse Krazo committers and contributors
+    Copyright (c) 2019-2022 Eclipse Krazo committers and contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -19,4 +19,24 @@
 ////
 == View Engines
 
-TODO: Describe each view engine in a separate subsection.
+Eclipse Krazo contains two view engine implementation out of the box: JSP and JSF. Those are required by the specification and will be shortly be introduced in this chapter.
+
+In case you search for view engines not covered by the specification, please have a look into the link:https://github.com/eclipse-ee4j/krazo-extensions[Krazo Extensions repository,window=_blank]. There you'll find implementations for
+Thymeleaf, Freemarker and many more.
+
+Anyway, if you want to implement your own custom view engine, please refer to the chapter link:_extensions.adoc#_writing_extensions[Writing extensions] covered later in this document.
+
+=== JSP view engine
+
+The MVC specification requires implementations to provide a view engine using JSP as template language. To use this
+view engine you've nothing more to do as adding a JSP ending on `.jsp` or `.jspx` into the configured view directory
+and call it from the controller.
+
+=== JSF view engine
+
+The JSF view engine is, as well as the JSP engine, required to be part of an MVC specification compatible implementation.
+This view engine enables you to use Facelets as template language. To use this language, your server needs to provide a JSF
+implementation and your template needs to end on `.xhtml`.
+
+Please be aware of the fact, that some features known from JSF won't work. This is due to the fact, that JSF and Jakarta MVC follow different architectural approaches. Also this view engine is discussed to be removed, or at least going to
+be optional, in Jakarta MVC 3.0.


### PR DESCRIPTION
- Remove version of Jakarta MVC
- Add hint which Jakarta EE version is assumed as default

Improve quickstart documentation

- Remove duplicated information
- Fix parsing issues in XML listings
- Remove most of CXF specific information
- Remove information about 'context.xml' as there are no problems
  without it (at least T. Erdle couldn't encounter them)
- Remove detail information about Thorntail

Update copyright date

Replace JAX-RS with Jakarta REST inside quickstart

Extend missing documentation

- Describe common configuration properties
- Describe out of the box view engines
- Describe the Krazo SPIs

Describe how view engine can be implemented

Replace GitHub CI badge with Jenkins badge

fixes: #330