### PR TITLE
Install compile dependencies in local maven repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,15 +11,15 @@ pipeline {
     stage("Compile") {
       steps {
         withMaven() {
-          sh "mvn -Pstaging clean compile"
+          sh "mvn -Pstaging compile"
         }
       }
     }
 
-    stage("Tests") {
+    stage("Unit Tests & install") {
       steps {
         withMaven() {
-          sh "mvn -Pstaging test"
+          sh "mvn -Pstaging install"
         }
       }
     }


### PR DESCRIPTION
Made a little mistake which only occurs in the testsuite when a core artifact needs a new build. This won't happen with just `mvn compile`, so I made the second step to test and install the artifacts.