### PR TITLE
336 update archetype for ee10

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
-  ~ Copyright (c) 2020 Eclipse Krazo committers and contributors
+  ~ Copyright (c) 2020, 2022 Eclipse Krazo committers and contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@
         <version>3.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>krazo-jakartaee9-archetype</artifactId>
+    <artifactId>krazo-jakartaee-archetype</artifactId>
     <packaging>maven-archetype</packaging>
-    <name>Archetype for Jakarta EE 9 with Eclipse Krazo</name>
+    <name>Archetype for Jakarta EE application containing Jakarta MVC and Eclipse Krazo</name>
 
     <description>
-        Archetype for basic Jakarta EE 9 App with the MVC API and Eclipse Krazo
+        Archetype for basic Jakarta EE Application containing Jakarta MVC and Eclipse Krazo
     </description>
 
     <build>

--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2020 Eclipse Krazo committers and contributors
+  ~ Copyright (c) 2020, 2022 Eclipse Krazo committers and contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
             <defaultValue>jersey</defaultValue>
         </requiredProperty>
         <requiredProperty key="javaRelease">
-            <defaultValue>1.8</defaultValue>
+            <defaultValue>11</defaultValue>
         </requiredProperty>
     </requiredProperties>
 </archetype-descriptor>

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,10 +10,10 @@
     <name>\${artifactId}</name>
 
     <properties>
-        <jakartaee-api.version>9.0.0</jakartaee-api.version>
+        <jakartaee-api.version>${jakartaee-api.version}</jakartaee-api.version>
         <krazo.version>${project.version}</krazo.version>
         <jakarta.mvc-api.version>${spec.version}</jakarta.mvc-api.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>5.9.0</junit.version>
     </properties>
 
     <dependencies>
@@ -45,8 +45,8 @@
         #end
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <version>\${junit.version}</version>
             <scope>test</scope>
         </dependency>
@@ -55,7 +55,6 @@
     <build>
         <finalName>\${artifactId}</finalName>
         <plugins>
-            #if (${javaRelease} != '1.8' || '1.7' || '1.6')
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -71,24 +70,6 @@
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
-            #else
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>${javaRelease}</source>
-                    <target>${javaRelease}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
-            </plugin>
-            #end
         </plugins>
     </build>
 </project>

--- a/archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-       bean-discovery-mode="all" version="3.0">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="annotated" version="4.0">
 </beans>

--- a/archetype/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,8 +1,8 @@
 package ${package};
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Dummy Test
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertTrue;
 public class AppTest {
 
     @Test
-    public void test() {
+    void test() {
         assertTrue(true);
     }
 }

--- a/documentation/src/main/asciidoc/_quickstart.adoc
+++ b/documentation/src/main/asciidoc/_quickstart.adoc
@@ -39,30 +39,57 @@ This archetype comes with the following setups:
 - Jakarta EE 9: MVC 2.0, Krazo 2.0.x
 - Jakarta EE 10: MVC 2.1, Krazo 3.0.0
 
+Please note that since Krazo 3.0.0 the name of the archetype changed. Before this release, all archetypes contained the target Jakarta EE release in their names which led to confusing versioning. Since Krazo 3.0.0 the archetype targets the same Jakarta EE release than Krazo and the corresponding Jakarta MVC API.
+
 ===== How to use the archetype
 
 The usage of the archetype is really easy. Depending on your application server, just run one of these commands in your command line.
 
-====== Glassfish / Payara (Jersey)
+====== Glassfish / Payara (Jersey) (since Krazo 3.0.0)
 
 [source, subs="attributes"]
 ----
 mvn archetype:generate \
 -DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee[8|9|10]-archetype \
--DarchetypeVersion=[1.1.0 | 2.0.x | 3.0.0]  \
+-DarchetypeArtifactId=krazo-jakartaee-archetype \
+-DarchetypeVersion=KRAZO VERSION  \
 -DgroupId=YOUR GROUP ID\
 -DartifactId=YOUR ARTIFACT ID
 ----
 
-====== Wildfly (RESTEasy) / OpenLiberty >= 21.x
+====== Wildfly (RESTEasy) / OpenLiberty >= 21.x (since Krazo 3.0.0)
 
 [source, subs="attributes"]
 ----
 mvn archetype:generate \
 -DarchetypeGroupId=org.eclipse.krazo \
--DarchetypeArtifactId=krazo-jakartaee[8|9|10]-archetype \
--DarchetypeVersion=[1.1.0 | 2.0.x | 3.0.0] \
+-DarchetypeArtifactId=krazo-jakartaee-archetype \
+-DarchetypeVersion=KRAZO VERSION \
+-DgroupId=YOUR GROUP ID \
+-DartifactId=YOUR ARTIFACT ID \
+-DkrazoImpl=resteasy
+----
+
+====== Glassfish / Payara (Jersey) (before Krazo 3.0.0)
+
+[source, subs="attributes"]
+----
+mvn archetype:generate \
+-DarchetypeGroupId=org.eclipse.krazo \
+-DarchetypeArtifactId=krazo-jakartaee[8|9]-archetype \
+-DarchetypeVersion=[1.1.0 | 2.0.x]  \
+-DgroupId=YOUR GROUP ID\
+-DartifactId=YOUR ARTIFACT ID
+----
+
+====== Wildfly (RESTEasy) / OpenLiberty >= 21.x (before Krazo 3.0.0)
+
+[source, subs="attributes"]
+----
+mvn archetype:generate \
+-DarchetypeGroupId=org.eclipse.krazo \
+-DarchetypeArtifactId=krazo-jakartaee[8|9]-archetype \
+-DarchetypeVersion=[1.1.0 | 2.0.x] \
 -DgroupId=YOUR GROUP ID \
 -DartifactId=YOUR ARTIFACT ID \
 -DkrazoImpl=resteasy


### PR DESCRIPTION
This PR updates the archetype according to #336. As stated in the first commit, I changed the name so we have _one_ archetype artifact whose Jakarta EE release is equal to the API version's. Also it updates to JUnit 5, as Arquillian seems to run well with it in the meanwhile.