### PR TITLE
Fix annotation check for controller methods in RESTEasy

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
@@ -169,6 +169,20 @@ public final class AnnotationUtils {
     }
 
     /**
+     * Determines if an annotation is present on a method or its declaring class.
+     *
+     * @param method         the {@link Method} to check for a specific annotation
+     * @param annotationType the annotation's type
+     * @param <T>            the type of the annotation
+     * @return <code>true</code> in case the method or its declaring class is annotated with the passed annotationType
+     * @see #hasAnnotation(Class, Class)
+     * @see #hasAnnotation(Method, Class)
+     */
+    public static <T extends Annotation> boolean hasAnnotationOnClassOrMethod(final Method method, Class<T> annotationType) {
+        return hasAnnotation(method.getDeclaringClass(), annotationType) || hasAnnotation(method, annotationType);
+    }
+
+    /**
      * Determines if a method has one or more MVC or JAX-RS annotations on it.
      *
      * @param method method to check for MVC or JAX-RS annotations.

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.krazo.util;
 
+import jakarta.ws.rs.POST;
 import org.junit.Test;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -97,6 +98,13 @@ public class AnnotationUtilsTest {
         assertFalse(AnnotationUtils.hasAnnotation(NoInheritanceController.class.getMethod("start"), Path.class));
     }
 
+    @Test
+    public void hasAnnotationOnClassOrMethodForMethod() throws NoSuchMethodException {
+        assertTrue(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), Controller.class));
+        assertTrue(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), View.class));
+        assertFalse(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), POST.class));
+    }
+
     @Controller
     @Path("start")
     static class SomeController {
@@ -145,6 +153,7 @@ public class AnnotationUtilsTest {
         public void start() {
         }
     }
+
 }
 
 

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
@@ -48,8 +48,8 @@ class KrazoGeneralValidator implements GeneralValidator {
 
     @Override
     public boolean isMethodValidatable(Method method) {
-
-        boolean mvcControllerMethod = AnnotationUtils.hasAnnotation(method, Controller.class);
+        // method is validatable when either class or method is annotated.
+        boolean mvcControllerMethod = AnnotationUtils.hasAnnotationOnClassOrMethod(method, Controller.class);
 
         return !mvcControllerMethod && delegate.isMethodValidatable(method);
 


### PR DESCRIPTION
While fixing #334 (PR #335) we introduced a small bug during the check if a method needs to be processed by the general validator or not. Because of this bug, the implementation checked only if a method is annotated with `@Controller`, but not if this is the case for the whole class. The result was Krazo not handling invalid input correctly.

This fix adds the ability to check if the method OR the declaring class is annotated with `@Controller`, so we ensure we really have something that needs to be handled by MVC.

This fix needs to be backported to Krazo 3.0.x.

fixes: #342