### PR TITLE
Ignore non-MVC requests when validating input

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
+++ b/core/src/main/java/org/eclipse/krazo/util/AnnotationUtils.java
@@ -169,6 +169,20 @@ public final class AnnotationUtils {
     }
 
     /**
+     * Determines if an annotation is present on a method or its declaring class.
+     *
+     * @param method         the {@link Method} to check for a specific annotation
+     * @param annotationType the annotation's type
+     * @param <T>            the type of the annotation
+     * @return <code>true</code> in case the method or its declaring class is annotated with the passed annotationType
+     * @see #hasAnnotation(Class, Class)
+     * @see #hasAnnotation(Method, Class)
+     */
+    public static <T extends Annotation> boolean hasAnnotationOnClassOrMethod(final Method method, Class<T> annotationType) {
+        return hasAnnotation(method.getDeclaringClass(), annotationType) || hasAnnotation(method, annotationType);
+    }
+
+    /**
      * Determines if a method has one or more MVC or JAX-RS annotations on it.
      *
      * @param method method to check for MVC or JAX-RS annotations.

--- a/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
+++ b/core/src/test/java/org/eclipse/krazo/util/AnnotationUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.krazo.util;
 
+import jakarta.ws.rs.POST;
 import org.junit.Test;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -97,6 +98,13 @@ public class AnnotationUtilsTest {
         assertFalse(AnnotationUtils.hasAnnotation(NoInheritanceController.class.getMethod("start"), Path.class));
     }
 
+    @Test
+    public void hasAnnotationOnClassOrMethodForMethod() throws NoSuchMethodException {
+        assertTrue(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), Controller.class));
+        assertTrue(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), View.class));
+        assertFalse(AnnotationUtils.hasAnnotationOnClassOrMethod(someController.getClass().getMethod("start"), POST.class));
+    }
+
     @Controller
     @Path("start")
     static class SomeController {
@@ -145,6 +153,7 @@ public class AnnotationUtilsTest {
         public void start() {
         }
     }
+
 }
 
 

--- a/jersey/src/main/java/org/eclipse/krazo/jersey/validation/KrazoValidationInterceptor.java
+++ b/jersey/src/main/java/org/eclipse/krazo/jersey/validation/KrazoValidationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.eclipse.krazo.util.AnnotationUtils;
 
 import jakarta.mvc.Controller;
 
+import java.lang.reflect.Method;
+
 /**
  * This interceptor prevents Jersey from performing validation for MVC requests. This
  * is required because, we need to make sure that controller is always invoked as we
@@ -41,16 +43,14 @@ public class KrazoValidationInterceptor implements ValidationInterceptor {
     @Override
     public void onValidate(ValidationInterceptorContext context) {
 
-        /*
-         * TODO: Won't work correctly for mixed controller/resource methods.
-         */
-        Class<?> resourceClass = context.getResource().getClass();
-        boolean mvcRequest = AnnotationUtils.hasAnnotationOnClassOrMethod(resourceClass, Controller.class);
+        final Class<?> resourceClass = context.getResource().getClass();
+        final Method handledMethod = context.getInvocable().getDefinitionMethod();
 
-        if (!mvcRequest) {
+        boolean mvcClass = AnnotationUtils.hasAnnotation(resourceClass, Controller.class);
+        boolean mvcMethod = AnnotationUtils.hasAnnotation(handledMethod, Controller.class);
+
+        if (!mvcClass && !mvcMethod) {
             context.proceed();
         }
-
     }
-
 }

--- a/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
+++ b/resteasy/src/main/java/org/eclipse/krazo/resteasy/validation/KrazoGeneralValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019 Eclipse Krazo committers and contributors
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import java.lang.reflect.Method;
  */
 class KrazoGeneralValidator implements GeneralValidator {
 
-    private GeneralValidator delegate;
+    private final GeneralValidator delegate;
 
     KrazoGeneralValidator(GeneralValidator delegate) {
         this.delegate = delegate;
@@ -40,10 +40,7 @@ class KrazoGeneralValidator implements GeneralValidator {
 
     @Override
     public boolean isValidatable(Class<?> clazz) {
-
-        // TODO: Won't work correctly for mixed controller/resource methods.
-        boolean mvcController =
-                AnnotationUtils.hasAnnotationOnClassOrMethod(clazz, Controller.class);
+        boolean mvcController = AnnotationUtils.hasAnnotation(clazz, Controller.class);
 
         return !mvcController && delegate.isValidatable(clazz);
 
@@ -51,10 +48,8 @@ class KrazoGeneralValidator implements GeneralValidator {
 
     @Override
     public boolean isMethodValidatable(Method method) {
-
-        // TODO: Won't work correctly for mixed controller/resource methods.
-        boolean mvcControllerMethod =
-                AnnotationUtils.hasAnnotationOnClassOrMethod(method.getDeclaringClass(), Controller.class);
+        // method is validatable when either class or method is annotated.
+        boolean mvcControllerMethod = AnnotationUtils.hasAnnotationOnClassOrMethod(method, Controller.class);
 
         return !mvcControllerMethod && delegate.isMethodValidatable(method);
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -19,8 +19,8 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -178,6 +178,13 @@
             <version>1.3.2</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
@@ -198,7 +205,8 @@
                 </executions>
                 <configuration>
                     <systemPropertyVariables>
-                        <project.build.finalName>${project.build.finalName}</project.build.finalName>
+                        <project.build.finalName>${project.build.finalName}
+                        </project.build.finalName>
                         <project.build.sourceEncoding>${project.build.sourceEncoding}
                         </project.build.sourceEncoding>
                     </systemPropertyVariables>

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/MixedResource.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/MixedResource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.mvc.Controller;
+import jakarta.mvc.Models;
+import jakarta.mvc.UriRef;
+import jakarta.mvc.binding.BindingResult;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@RequestScoped
+@Path("/mixed")
+public class MixedResource {
+
+    @Inject
+    TodoHolder holder;
+
+    @Inject
+    Models models;
+
+    @Inject
+    BindingResult bindingResult;
+
+    @GET
+    @Controller
+    @Produces(MediaType.TEXT_HTML)
+    public String indexMvc() {
+        models.put("todos", holder.getTodos());
+        return "index.jsp";
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response indexApi() {
+        return Response.ok(holder.getTodos()).build();
+    }
+
+    @POST
+    @UriRef("create")
+    @Controller
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public String createMvc(@Valid @BeanParam TodoForm form) {
+        if (bindingResult.isFailed()) {
+            models.put("validationPerformed", true);
+            return "index.jsp";
+        }
+
+        holder.addTodo(Todo.fromForm(form));
+
+        return "redirect:/mixed";
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createApi(@Valid Todo todo) {
+
+        holder.addTodo(todo);
+
+        return Response.noContent().build();
+    }
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/MyApplication.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/MyApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@ApplicationPath("resources")
+public class MyApplication extends Application {
+
+    @Override
+    public Map<String, Object> getProperties() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put("myproperty", true);
+        return map;
+    }
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/Todo.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/Todo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public class Todo {
+
+	@JsonbProperty
+	@NotBlank
+	private String title;
+
+	@JsonbProperty
+	@NotBlank
+	private String content;
+
+	public static Todo fromForm(final TodoForm form) {
+		return new Todo(form.getTitle(), form.getContent());
+	}
+
+	public Todo() {
+	}
+
+	private Todo(final String title, final String content) {
+		this.title = title;
+		this.content = content;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(final String title) {
+		this.title = title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(final String content) {
+		this.content = content;
+	}
+
+	@Override
+	public String toString() {
+		return "Todo{" +
+				"title='" + title + '\'' +
+				", content='" + content + '\'' +
+				'}';
+	}
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/TodoForm.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/TodoForm.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import jakarta.mvc.binding.MvcBinding;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.ws.rs.FormParam;
+
+public class TodoForm {
+
+	@FormParam("title")
+	@NotBlank
+	@MvcBinding
+	private String title;
+
+	@FormParam("content")
+	@NotBlank
+	@MvcBinding
+	private String content;
+
+	public TodoForm() {
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(final String title) {
+		this.title = title;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(final String content) {
+		this.content = content;
+	}
+
+	@Override
+	public String toString() {
+		return "Todo{" +
+				"title='" + title + '\'' +
+				", content='" + content + '\'' +
+				'}';
+	}
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/TodoHolder.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/TodoHolder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class TodoHolder {
+
+    private List<Todo> TODOS;
+
+    @PostConstruct
+    void init() {
+        TODOS = new ArrayList<>();
+    }
+
+    public List<Todo> getTodos() {
+        return new ArrayList<>(TODOS);
+    }
+
+    public void addTodo(final Todo todo) {
+        TODOS.add(todo);
+    }
+}

--- a/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/package-info.java
+++ b/testsuite/src/main/java/org/eclipse/krazo/test/mixedsetup/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * This package contains the test setup for testing Krazo in mixed resource setups,
+ * so e.g. one resource supporting HTML via Krazo and JSON via JSONB.
+ */
+package org.eclipse.krazo.test.mixedsetup;

--- a/testsuite/src/main/resources/mixedsetup/views/index.jsp
+++ b/testsuite/src/main/resources/mixedsetup/views/index.jsp
@@ -1,0 +1,19 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+	<title>Mixed resource test</title>
+</head>
+<body>
+<p id="validation-performed">${validationPerformed}</p>
+
+<form name="todoForm" action="${mvc.uri('create')}" method="post">
+	<label for="title">Title</label>
+	<input id="title" type="text" name="title">
+	<br/>
+	<label for="content">Content</label>
+	<input id="content" type="text" name="content">
+	<br/>
+	<input type="submit" name="submit" value="Submit">
+</form>
+</body>
+</html>

--- a/testsuite/src/test/java/org/eclipse/krazo/test/mixedsetup/MixedSetupValidationIT.java
+++ b/testsuite/src/test/java/org/eclipse/krazo/test/mixedsetup/MixedSetupValidationIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2018, 2022 Eclipse Krazo committers and contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.krazo.test.mixedsetup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.eclipse.krazo.test.util.WebArchiveBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests resource containing MVC as well as non-MVC methods. Sets its focus in Bean Validation.
+ */
+@RunWith(Arquillian.class)
+public class MixedSetupValidationIT {
+
+    private static final String WEB_INF_SRC = "src/main/resources/mixedsetup/";
+
+    @ArquillianResource
+    private URL baseURL;
+
+    private WebClient webClient;
+    private OkHttpClient httpClient;
+
+    @Before
+    public void setUp() {
+        webClient = new WebClient();
+        webClient.getOptions()
+            .setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions()
+            .setRedirectEnabled(true);
+
+        httpClient = new OkHttpClient().newBuilder()
+            .readTimeout(Duration.of(1000, ChronoUnit.MILLIS))
+            .writeTimeout(Duration.of(1000, ChronoUnit.MILLIS))
+            .build();
+    }
+
+    @Deployment(testable = false, name = "mixed")
+    public static WebArchive createDeployment() {
+        return new WebArchiveBuilder()
+            .addPackage("org.eclipse.krazo.test.mixedsetup")
+            .addView(Paths.get(WEB_INF_SRC).resolve("views/index.jsp").toFile(), "index.jsp")
+            .addBeansXml()
+            .build();
+    }
+
+    @After
+    public void teardown() {
+        webClient.close();
+    }
+
+    @Test
+    public void shouldNotShowMessageWhenMvcInputIsValid() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/mixed");
+
+        final HtmlForm form = page.getFormByName("todoForm");
+        form.getInputByName("title").setValueAttribute("Test");
+        form.getInputByName("content").setValueAttribute("Test");
+
+        final HtmlPage resultPage = form.getInputByName("submit").click();
+
+        assertTrue(resultPage.getElementById("validation-performed").getTextContent().isEmpty());
+    }
+
+    @Test
+    public void shouldShowMessageWhenMvcInputIsInvalid() throws Exception {
+        final HtmlPage page = webClient.getPage(baseURL + "resources/mixed");
+
+        final HtmlForm form = page.getFormByName("todoForm");
+        form.getInputByName("title").setValueAttribute("Test");
+
+        final HtmlPage resultPage = form.getInputByName("submit").click();
+        assertTrue(
+            resultPage.getElementById("validation-performed").getTextContent().contains("true"));
+    }
+
+    @Test
+    public void shouldReturnHttp204WhenAPIInputIsValid() throws Exception {
+        final String payload = "{\"title\":\"Test\",\"content\":\"Test\"}";
+
+        final Request request = new Request.Builder()
+            .url(URI.create(baseURL + "resources/mixed").toURL())
+            .post(RequestBody.create(payload, okhttp3.MediaType.parse("application/json")))
+            .build();
+
+        final okhttp3.Response response = httpClient.newCall(request).execute();
+
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.code());
+    }
+
+    @Test
+    public void shouldReturnHttp400WhenAPIInputIsInvalid() throws Exception {
+        final String payload = "{\"title\":\"Test\",\"content\":\"\"}";
+
+        final Request request = new Request.Builder()
+            .url(URI.create(baseURL + "resources/mixed").toURL())
+            .post(RequestBody.create(payload, okhttp3.MediaType.parse("application/json")))
+            .build();
+
+        final okhttp3.Response response = httpClient.newCall(request).execute();
+
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), response.code());
+    }
+}
+


### PR DESCRIPTION
This commit backports the validation issue when using mixed MVC and non-MVC methods. Because the original test is using JDK 11 API, an external HTTP client was added in test scope.

@ivargrimstad  / @chkal please do me a favor and run the tests locally. I think I got weird failures because of my JVM / Glassfish settings.