### PR TITLE
Add overrides for other write methods in DelegatingServletOutputStream

### DIFF
--- a/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
+++ b/core/src/main/java/org/eclipse/krazo/core/ViewableWriter.java
@@ -197,6 +197,16 @@ public class ViewableWriter implements MessageBodyWriter<Viewable> {
         }
 
         @Override
+        public void write(final byte[] b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            out.write(b, off, len);
+        }
+
+        @Override
         public boolean isReady() {
             return false;
         }


### PR DESCRIPTION
This adds delegating overrides for `write(byte[])` and `write(byte[], int, int)` to `DelegatingServletOutputStream`.

In my environment, the single delegating method meant that my platform's native write method was called once per character output from JSP due to the base `java.io.OutputStream#write` implementation. This change reduces the same page to four calls to the native bulk write, speeding things up a good bit.